### PR TITLE
feat: プロフィールにランキング情報を追加&ランキング更新通知実装

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/Gigantic.kt
+++ b/src/main/kotlin/click/seichi/gigantic/Gigantic.kt
@@ -16,8 +16,10 @@ import click.seichi.gigantic.event.events.TickEvent
 import click.seichi.gigantic.extension.*
 import click.seichi.gigantic.listener.*
 import click.seichi.gigantic.listener.packet.ExperienceOrbSpawn
+import click.seichi.gigantic.message.messages.RankingMessages
 import click.seichi.gigantic.player.Defaults
 import click.seichi.gigantic.player.ExpReason
+import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.player.skill.Skill
 import click.seichi.gigantic.player.spell.Spell
 import click.seichi.gigantic.player.spell.spells.SkyWalk
@@ -39,6 +41,7 @@ import org.bukkit.Material
 import org.bukkit.block.Block
 import org.bukkit.command.CommandExecutor
 import org.bukkit.entity.ArmorStand
+import org.bukkit.entity.Player
 import org.bukkit.event.Listener
 import org.bukkit.plugin.java.JavaPlugin
 import org.jetbrains.exposed.sql.Database
@@ -291,6 +294,12 @@ class Gigantic : JavaPlugin() {
             RankingPlayerCacheMemory.clearAll()
             RankingPlayerCacheMemory.addAll(*uniqueIdSet.toTypedArray())
         }
+        Bukkit.getServer().onlinePlayers
+            .filterNotNull()
+            .filter { it.isValid && ToggleSetting.UPDATE_RANKING.getToggle(it) }
+            .forEach { player ->
+                player.sendMessage(RankingMessages.UPDATE_RANKING.asSafety(player.wrappedLocale))
+            }
     }
 
 

--- a/src/main/kotlin/click/seichi/gigantic/item/items/BagButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/BagButtons.kt
@@ -56,8 +56,6 @@ object BagButtons {
 
                 lore.add("${ChatColor.GREEN}MCID: ${ChatColor.WHITE}" + player.name)
 
-                // abovePlayerName, aboveDiff, belowPlayerName, belowDiff を使用して処理を行う
-
                 lore.addAll(listOf(
                         ProfileMessages.PROFILE_LEVEL(player.wrappedLevel),
                         ProfileMessages.PROFILE_EXP(player.wrappedLevel, player.wrappedExp),

--- a/src/main/kotlin/click/seichi/gigantic/item/items/BagButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/BagButtons.kt
@@ -2,7 +2,6 @@ package click.seichi.gigantic.item.items
 
 import click.seichi.gigantic.Gigantic
 import click.seichi.gigantic.acheivement.Achievement
-import click.seichi.gigantic.cache.RankingPlayerCacheMemory
 import click.seichi.gigantic.cache.key.Keys
 import click.seichi.gigantic.database.dao.DonateHistory
 import click.seichi.gigantic.database.dao.user.User
@@ -10,7 +9,6 @@ import click.seichi.gigantic.database.table.DonateHistoryTable
 import click.seichi.gigantic.event.events.SenseEvent
 import click.seichi.gigantic.extension.*
 import click.seichi.gigantic.item.Button
-import click.seichi.gigantic.item.items.menu.RankingButtons
 import click.seichi.gigantic.menu.menus.*
 import click.seichi.gigantic.menu.menus.shop.DonateEffectShopMenu
 import click.seichi.gigantic.menu.menus.shop.VoteEffectShopMenu
@@ -21,7 +19,6 @@ import click.seichi.gigantic.message.messages.menu.*
 import click.seichi.gigantic.player.Defaults
 import click.seichi.gigantic.player.DonateTicket
 import click.seichi.gigantic.quest.Quest
-import click.seichi.gigantic.ranking.Score
 import click.seichi.gigantic.sound.sounds.PlayerSounds
 import click.seichi.gigantic.sound.sounds.WillSpiritSounds
 import click.seichi.gigantic.util.Random

--- a/src/main/kotlin/click/seichi/gigantic/item/items/BagButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/BagButtons.kt
@@ -2,6 +2,7 @@ package click.seichi.gigantic.item.items
 
 import click.seichi.gigantic.Gigantic
 import click.seichi.gigantic.acheivement.Achievement
+import click.seichi.gigantic.cache.RankingPlayerCacheMemory
 import click.seichi.gigantic.cache.key.Keys
 import click.seichi.gigantic.database.dao.DonateHistory
 import click.seichi.gigantic.database.dao.user.User
@@ -9,6 +10,7 @@ import click.seichi.gigantic.database.table.DonateHistoryTable
 import click.seichi.gigantic.event.events.SenseEvent
 import click.seichi.gigantic.extension.*
 import click.seichi.gigantic.item.Button
+import click.seichi.gigantic.item.items.menu.RankingButtons
 import click.seichi.gigantic.menu.menus.*
 import click.seichi.gigantic.menu.menus.shop.DonateEffectShopMenu
 import click.seichi.gigantic.menu.menus.shop.VoteEffectShopMenu
@@ -19,6 +21,7 @@ import click.seichi.gigantic.message.messages.menu.*
 import click.seichi.gigantic.player.Defaults
 import click.seichi.gigantic.player.DonateTicket
 import click.seichi.gigantic.quest.Quest
+import click.seichi.gigantic.ranking.Score
 import click.seichi.gigantic.sound.sounds.PlayerSounds
 import click.seichi.gigantic.sound.sounds.WillSpiritSounds
 import click.seichi.gigantic.util.Random
@@ -56,9 +59,13 @@ object BagButtons {
 
                 lore.add("${ChatColor.GREEN}MCID: ${ChatColor.WHITE}" + player.name)
 
+                // abovePlayerName, aboveDiff, belowPlayerName, belowDiff を使用して処理を行う
+
                 lore.addAll(listOf(
                         ProfileMessages.PROFILE_LEVEL(player.wrappedLevel),
                         ProfileMessages.PROFILE_EXP(player.wrappedLevel, player.wrappedExp),
+                        ProfileMessages.PROFILE_ABOVE_RANKING(player,player.wrappedExp),
+                        ProfileMessages.PROFILE_BELOW_RANKING(player,player.wrappedExp),
                         // 投票・寄付機能がないためコメントアウト
                         // ProfileMessages.PROFILE_VOTE_POINT(player.totalVote),
                         // ProfileMessages.PROFILE_DONATION(player.totalDonation),

--- a/src/main/kotlin/click/seichi/gigantic/listener/WorldListener.kt
+++ b/src/main/kotlin/click/seichi/gigantic/listener/WorldListener.kt
@@ -42,25 +42,25 @@ class WorldListener : Listener {
 
     @EventHandler
     fun onWorldSave(event: WorldSaveEvent) {
-        // プレイヤーデータの逐次保存
-        val onlineIdSet = Bukkit.getOnlinePlayers().map { it.uniqueId }.toSet()
+        if (event.world.environment == org.bukkit.World.Environment.NORMAL) {
+            // プレイヤーデータの逐次保存
+            val onlineIdSet = Bukkit.getOnlinePlayers().map { it.uniqueId }.toSet()
 
-        if (onlineIdSet.isEmpty()) return
-
-        runTaskLaterAsync(Defaults.PLAYER_DATA_SAVE_DELAY) {
+            if (onlineIdSet.isEmpty()) return
+            runTaskLaterAsync(Defaults.PLAYER_DATA_SAVE_DELAY) {
             onlineIdSet.forEach { uniqueId ->
                 // 保存処理
                 try {
-                    PlayerCacheMemory.write(uniqueId)
+                PlayerCacheMemory.write(uniqueId)
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                e.printStackTrace()
                 }
             }
-        }
-
-        // ランキングデータの更新
-        runTaskLaterAsync(Defaults.RANK_DATA_SAVE_DELAY) {
+            }
+            // ランキングデータの更新
+            runTaskLaterAsync(Defaults.RANK_DATA_SAVE_DELAY) {
             Gigantic.PLUGIN.updateRanking()
+            }
         }
     }
 

--- a/src/main/kotlin/click/seichi/gigantic/message/Tips.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/Tips.kt
@@ -125,6 +125,12 @@ enum class Tips(
                         "${ChatColor.AQUA}" +
                         "https://s.seichi-haru.pgw.jp/discord"
             ), 2L)),
+    RANKING_UPDATE_TIPS(LinedChatMessage(ChatMessageProtocol.CHAT,
+            LocalizedText(
+                Locale.JAPANESE to Defaults.TIPS_PREFIX +
+                        "${ChatColor.WHITE}" +
+                        "詳細設定からランキングの更新時に通知を受け取ることができるぞ！"
+            ), 2L)),
     ;
 
     fun sendTo(player: Player) {

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/RankingMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/RankingMessages.kt
@@ -109,5 +109,8 @@ object RankingMessages {
     val CLICK_TO_MY_RANKING_PAGE = LocalizedText(
             Locale.JAPANESE to "${ChatColor.GREEN}${ChatColor.UNDERLINE}クリックして自分がいるページへ"
     )
+    val UPDATE_RANKING = LocalizedText(
+            Locale.JAPANESE to "${ChatColor.YELLOW}[お知らせ] ${ChatColor.GREEN}ランキングが更新されました。"
+    )
 
 }

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/menu/ProfileMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/menu/ProfileMessages.kt
@@ -5,6 +5,7 @@ import click.seichi.gigantic.cache.RankingPlayerCacheMemory
 import click.seichi.gigantic.cache.key.Keys
 import click.seichi.gigantic.config.PlayerLevelConfig
 import click.seichi.gigantic.extension.hasAptitude
+import click.seichi.gigantic.message.LinedChatMessage
 import click.seichi.gigantic.message.LocalizedText
 import click.seichi.gigantic.ranking.Score
 import click.seichi.gigantic.relic.Relic
@@ -79,13 +80,11 @@ object ProfileMessages {
                 }
             }
         }
-        if (rank == null || value == null || abovePlayerName == null || aboveDiff == null) {
-            LocalizedText( Locale.JAPANESE to "${ChatColor.RED}ランキングエラー")
-        }
-        if (rank == 1){
-            LocalizedText( Locale.JAPANESE to "${ChatColor.GOLD}あなたは現在1位です！")
-        } else {
-            LocalizedText(Locale.JAPANESE to "${ChatColor.GREEN}${rank?.minus(1)}位(${abovePlayerName})までとの差: ${ChatColor.WHITE}$aboveDiff")
+        when {
+            rank == 1 -> LocalizedText(Locale.JAPANESE to "${ChatColor.GOLD}あなたは現在1位です！")
+            rank == null || value == null || abovePlayerName == null || aboveDiff == null -> LocalizedText(Locale.JAPANESE to "${ChatColor.RED}ランキングエラー")
+            aboveDiff < 0 -> LocalizedText(Locale.JAPANESE to "${ChatColor.RED}ランキングが変動しました。更新までお待ち下さい")
+            else -> LocalizedText(Locale.JAPANESE to "${ChatColor.GREEN}${rank.minus(1)}位(${abovePlayerName})までとの差: ${ChatColor.WHITE}$aboveDiff")
         }
     }
     val PROFILE_BELOW_RANKING = { player: Player, value: BigDecimal ->
@@ -110,13 +109,12 @@ object ProfileMessages {
             }
         }
 
-        if (rank == null || value == null || isLastRank == null || belowPlayerName == null || belowDiff == null) {
-            LocalizedText( Locale.JAPANESE to "${ChatColor.RED}ランキングエラー")
-        }
-        if (isLastRank){
-            LocalizedText(Locale.JAPANESE to "${ChatColor.GRAY}あなたは現在最下位です...")
-        } else {
-            LocalizedText( Locale.JAPANESE to "${ChatColor.GREEN}${rank?.plus(1)}位(${belowPlayerName})までとの差: ${ChatColor.WHITE}$belowDiff")
+        when {
+            isLastRank == null -> LocalizedText(Locale.JAPANESE to "${ChatColor.RED}ランキングエラー")
+            isLastRank -> LocalizedText(Locale.JAPANESE to "${ChatColor.GRAY}あなたは現在最下位です...")
+            rank == null || value == null || belowPlayerName == null || belowDiff == null -> LocalizedText(Locale.JAPANESE to "${ChatColor.RED}ランキングエラー")
+            belowDiff < 0 -> LocalizedText(Locale.JAPANESE to "${ChatColor.RED}ランキングが変動しました。更新までお待ち下さい")
+            else -> LocalizedText(Locale.JAPANESE to "${ChatColor.GREEN}${rank.plus(1)}位(${belowPlayerName})までとの差: ${ChatColor.WHITE}$belowDiff")
         }
     }
 

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/menu/ProfileMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/menu/ProfileMessages.kt
@@ -5,7 +5,6 @@ import click.seichi.gigantic.cache.RankingPlayerCacheMemory
 import click.seichi.gigantic.cache.key.Keys
 import click.seichi.gigantic.config.PlayerLevelConfig
 import click.seichi.gigantic.extension.hasAptitude
-import click.seichi.gigantic.message.LinedChatMessage
 import click.seichi.gigantic.message.LocalizedText
 import click.seichi.gigantic.ranking.Score
 import click.seichi.gigantic.relic.Relic

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/menu/ProfileMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/menu/ProfileMessages.kt
@@ -1,8 +1,12 @@
 package click.seichi.gigantic.message.messages.menu
 
+import click.seichi.gigantic.Gigantic
+import click.seichi.gigantic.cache.RankingPlayerCacheMemory
+import click.seichi.gigantic.cache.key.Keys
 import click.seichi.gigantic.config.PlayerLevelConfig
 import click.seichi.gigantic.extension.hasAptitude
 import click.seichi.gigantic.message.LocalizedText
+import click.seichi.gigantic.ranking.Score
 import click.seichi.gigantic.relic.Relic
 import click.seichi.gigantic.will.Will
 import click.seichi.gigantic.will.WillGrade
@@ -16,6 +20,8 @@ import java.util.*
  * @author tar0ss
  */
 object ProfileMessages {
+    val score = Score.values().first { it == Score.EXP }
+    val ranking = Gigantic.RANKING_MAP[score]
 
     val TITLE = LocalizedText(
             Locale.JAPANESE to "プロフィール"
@@ -51,6 +57,66 @@ object ProfileMessages {
             LocalizedText(
                     Locale.JAPANESE to "${ChatColor.GREEN}経験値: ${ChatColor.WHITE}${exp.setScale(0, RoundingMode.FLOOR)} / ${expToNextLevel.setScale(0, RoundingMode.FLOOR)}"
             )
+        }
+    }
+    val PROFILE_ABOVE_RANKING = { player: Player, value: BigDecimal ->
+        val rank = ranking?.findRank(player.uniqueId)
+        var abovePlayerName: String? = null
+        var aboveDiff: Long? = null
+        if (rank != null) {
+            if (rank > 1) {
+                val aboveRank = rank - 1
+                val aboveUniqueId = ranking?.findUUID(aboveRank)
+                if (aboveUniqueId != null) {
+                    val abovePlayerCache = RankingPlayerCacheMemory.find(aboveUniqueId)
+                    if (abovePlayerCache != null) {
+                        abovePlayerName = abovePlayerCache.getOrPut(Keys.RANK_PLAYER_NAME)
+                        val aboveValue = ranking?.findValue(aboveUniqueId)
+                        if (aboveValue != null) {
+                            aboveDiff = aboveValue - value.toLong()!!
+                        }
+                    }
+                }
+            }
+        }
+        if (rank == null || value == null || abovePlayerName == null || aboveDiff == null) {
+            LocalizedText( Locale.JAPANESE to "${ChatColor.RED}ランキングエラー")
+        }
+        if (rank == 1){
+            LocalizedText( Locale.JAPANESE to "${ChatColor.GOLD}あなたは現在1位です！")
+        } else {
+            LocalizedText(Locale.JAPANESE to "${ChatColor.GREEN}${rank?.minus(1)}位(${abovePlayerName})までとの差: ${ChatColor.WHITE}$aboveDiff")
+        }
+    }
+    val PROFILE_BELOW_RANKING = { player: Player, value: BigDecimal ->
+        val rank = ranking?.findRank(player.uniqueId)
+
+        val isLastRank = rank != null && rank == ranking?.size
+        var belowPlayerName: String? = null
+        var belowDiff: Long? = null
+
+        if (rank != null){
+            val belowRank = rank + 1
+            val belowUniqueId = ranking?.findUUID(belowRank)
+            if (belowUniqueId != null) {
+                val belowPlayerCache = RankingPlayerCacheMemory.find(belowUniqueId)
+                if (belowPlayerCache != null) {
+                    belowPlayerName = belowPlayerCache.getOrPut(Keys.RANK_PLAYER_NAME)
+                    val belowValue = ranking?.findValue(belowUniqueId)
+                    if (belowValue != null) {
+                        belowDiff = value.toLong()!! - belowValue
+                    }
+                }
+            }
+        }
+
+        if (rank == null || value == null || isLastRank == null || belowPlayerName == null || belowDiff == null) {
+            LocalizedText( Locale.JAPANESE to "${ChatColor.RED}ランキングエラー")
+        }
+        if (isLastRank){
+            LocalizedText(Locale.JAPANESE to "${ChatColor.GRAY}あなたは現在最下位です...")
+        } else {
+            LocalizedText( Locale.JAPANESE to "${ChatColor.GREEN}${rank?.plus(1)}位(${belowPlayerName})までとの差: ${ChatColor.WHITE}$belowDiff")
         }
     }
 

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -54,6 +54,11 @@ enum class ToggleSetting(
             Locale.JAPANESE to "意志の交感中表示"
         ), true
     ),
+    UPDATE_RANKING(
+        8, LocalizedText(
+            Locale.JAPANESE to "ランキングの更新通知"
+        ), false
+    ),
     ;
 
     fun getName(locale: Locale) = localizedName.asSafety(locale)


### PR DESCRIPTION
このプルリクエストは、`Gigantic`プロジェクトに対するいくつかの変更を含んでおり、ランキング更新通知の追加や、ランキング情報の表示改善に焦点を当てています。主な変更点は、新しいクラスのインポート、ランキング更新通知の追加、そしてプロフィールメッセージにランキング詳細を追加する改善です。

### ランキング更新通知:

* [`src/main/kotlin/click/seichi/gigantic/Gigantic.kt`](diffhunk://#diff-da2f16110a11922342b9950532372c09fde0c1e0e10f24825864410f5c211957R297-R302):  
  プレイヤーが関連するトグル設定を有効にしている場合に、ランキング更新について通知するコードを追加しました。
* [`src/main/kotlin/click/seichi/gigantic/message/Tips.kt`](diffhunk://#diff-10fa6193243a485f0385ee03818b46b6f908beaf60b0b13dded472a68aa7c0e8R128-R133):  
  ランキング更新に関する新しいチップを追加しました。
* [`src/main/kotlin/click/seichi/gigantic/message/messages/RankingMessages.kt`](diffhunk://#diff-1aa9f474d5454130d6ff6b7547fed37484c4a7fc48a8e4db4aba43ecdd59770cR112-R114):  
  ランキング更新に関する新しいメッセージを追加しました。
* [`src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt`](diffhunk://#diff-3403c8ca7949399ff86b18cf8ded4fd031c36a51136baff4a1f5057bca1bbd6cR57-R61):  
  ランキング更新通知用の新しいトグル設定を追加しました。

### プロフィールメッセージの改善:

* [`src/main/kotlin/click/seichi/gigantic/item/items/BagButtons.kt`](diffhunk://#diff-e395eebf660478e0511298fb8bc6041e0ba31a357141bccbbbd0ad61f7cfd839R62-R68):  
  プレイヤーのランキング情報（上位と下位）を表示する新しいプロフィールメッセージを追加しました。
* [`src/main/kotlin/click/seichi/gigantic/message/messages/menu/ProfileMessages.kt`](diffhunk://#diff-7460006834024e9a02f89fa7da9ee23ed5898e3e0db300eb5bbb52d5a050ce48R63-R119):  
  プレイヤーのランキング情報（上位と下位）を取得し、表示するメソッドを追加しました。
