### PR TITLE
feat: 設定項目を増やす・設定画面の整理 

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/item/items/menu/SettingButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/menu/SettingButtons.kt
@@ -4,8 +4,10 @@ import click.seichi.gigantic.cache.key.Keys
 import click.seichi.gigantic.config.Config
 import click.seichi.gigantic.extension.*
 import click.seichi.gigantic.item.Button
+import click.seichi.gigantic.menu.menus.setting.CategorySettingMenu
 import click.seichi.gigantic.menu.menus.setting.ToolSwitchSettingMenu
 import click.seichi.gigantic.message.messages.BagMessages
+import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.sound.sounds.PlayerSounds
 import org.bukkit.ChatColor
 import org.bukkit.Material
@@ -75,8 +77,10 @@ object SettingButtons {
         }
 
         override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
-            //TODO: CategorySettingMenu実装後、変更
-            return false
+            if (event.inventory.holder === CategorySettingMenu(ToggleSetting.Category.DISPLAY)) return false
+            val menu = CategorySettingMenu(ToggleSetting.Category.DISPLAY)
+            menu.open(player)
+            return true
         }
 
     }
@@ -90,8 +94,10 @@ object SettingButtons {
         }
 
         override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
-            //TODO: CategorySettingMenu実装後、変更
-            return false
+            if (event.inventory.holder === CategorySettingMenu(ToggleSetting.Category.FUNCTION)) return false
+            val menu = CategorySettingMenu(ToggleSetting.Category.FUNCTION)
+            menu.open(player)
+            return true
         }
 
     }
@@ -105,8 +111,10 @@ object SettingButtons {
         }
 
         override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
-            //TODO: CategorySettingMenu実装後、変更
-            return false
+            if (event.inventory.holder === CategorySettingMenu(ToggleSetting.Category.NOTIFICATION)) return false
+            val menu = CategorySettingMenu(ToggleSetting.Category.NOTIFICATION)
+            menu.open(player)
+            return true
         }
 
     }

--- a/src/main/kotlin/click/seichi/gigantic/item/items/menu/SettingButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/menu/SettingButtons.kt
@@ -72,7 +72,8 @@ object SettingButtons {
             return itemStackOf(Material.ITEM_FRAME) {
                 setDisplayName("${ChatColor.AQUA}${ChatColor.UNDERLINE}"
                         + BagMessages.DISPLAY_SETTING.asSafety(player.wrappedLocale))
-                setLore(BagMessages.DISPLAY_SETTING_LORE.asSafety(player.wrappedLocale))
+                addLore(BagMessages.DISPLAY_SETTING_LORE_1.asSafety(player.wrappedLocale))
+                addLore(BagMessages.DISPLAY_SETTING_LORE_2.asSafety(player.wrappedLocale))
             }
         }
 
@@ -89,7 +90,8 @@ object SettingButtons {
             return itemStackOf(Material.REDSTONE) {
                 setDisplayName("${ChatColor.AQUA}${ChatColor.UNDERLINE}"
                         + BagMessages.FUNCTION_SETTING.asSafety(player.wrappedLocale))
-                setLore(BagMessages.FUNCTION_SETTING_LORE.asSafety(player.wrappedLocale))
+                addLore(BagMessages.FUNCTION_SETTING_LORE_1.asSafety(player.wrappedLocale))
+                addLore(BagMessages.FUNCTION_SETTING_LORE_2.asSafety(player.wrappedLocale))
             }
         }
 
@@ -106,7 +108,8 @@ object SettingButtons {
             return itemStackOf(Material.BELL) {
                 setDisplayName("${ChatColor.AQUA}${ChatColor.UNDERLINE}"
                         + BagMessages.NOTIFICATION_SETTING.asSafety(player.wrappedLocale))
-                setLore(BagMessages.NOTIFICATION_SETTING_LORE.asSafety(player.wrappedLocale))
+                addLore(BagMessages.NOTIFICATION_SETTING_LORE_1.asSafety(player.wrappedLocale))
+                addLore(BagMessages.NOTIFICATION_SETTING_LORE_2.asSafety(player.wrappedLocale))
             }
         }
 

--- a/src/main/kotlin/click/seichi/gigantic/item/items/menu/SettingButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/menu/SettingButtons.kt
@@ -65,5 +65,49 @@ object SettingButtons {
         }
 
     }
+    val DISPLAY_SETTING = object : Button {
+        override fun toShownItemStack(player: Player): ItemStack? {
+            return itemStackOf(Material.ITEM_FRAME) {
+                setDisplayName("${ChatColor.AQUA}${ChatColor.UNDERLINE}"
+                        + BagMessages.DISPLAY_SETTING.asSafety(player.wrappedLocale))
+                setLore(BagMessages.DISPLAY_SETTING_LORE.asSafety(player.wrappedLocale))
+            }
+        }
 
+        override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
+            //TODO: CategorySettingMenu実装後、変更
+            return false
+        }
+
+    }
+    val FUNCTION_SETTING = object : Button {
+        override fun toShownItemStack(player: Player): ItemStack? {
+            return itemStackOf(Material.REDSTONE) {
+                setDisplayName("${ChatColor.AQUA}${ChatColor.UNDERLINE}"
+                        + BagMessages.FUNCTION_SETTING.asSafety(player.wrappedLocale))
+                setLore(BagMessages.FUNCTION_SETTING_LORE.asSafety(player.wrappedLocale))
+            }
+        }
+
+        override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
+            //TODO: CategorySettingMenu実装後、変更
+            return false
+        }
+
+    }
+    val NOTIFICATION_SETTING = object : Button {
+        override fun toShownItemStack(player: Player): ItemStack? {
+            return itemStackOf(Material.BELL) {
+                setDisplayName("${ChatColor.AQUA}${ChatColor.UNDERLINE}"
+                        + BagMessages.NOTIFICATION_SETTING.asSafety(player.wrappedLocale))
+                setLore(BagMessages.NOTIFICATION_SETTING_LORE.asSafety(player.wrappedLocale))
+            }
+        }
+
+        override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
+            //TODO: CategorySettingMenu実装後、変更
+            return false
+        }
+
+    }
 }

--- a/src/main/kotlin/click/seichi/gigantic/listener/TipsListener.kt
+++ b/src/main/kotlin/click/seichi/gigantic/listener/TipsListener.kt
@@ -5,6 +5,7 @@ import click.seichi.gigantic.config.Config
 import click.seichi.gigantic.config.DebugConfig
 import click.seichi.gigantic.event.events.TickEvent
 import click.seichi.gigantic.message.Tips
+import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.util.Random
 import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
@@ -41,7 +42,7 @@ class TipsListener : Listener {
         Bukkit.getServer().onlinePlayers
                 .asSequence()
                 .filterNotNull()
-                .filter { it.isValid }
+                .filter { it.isValid && ToggleSetting.TIPS_NOTIFICATION.getToggle(it) }
                 .forEach { player ->
                     message.sendTo(player)
                 }

--- a/src/main/kotlin/click/seichi/gigantic/menu/menus/SettingMenu.kt
+++ b/src/main/kotlin/click/seichi/gigantic/menu/menus/SettingMenu.kt
@@ -21,61 +21,19 @@ import java.util.*
 object SettingMenu : Menu() {
 
     override val size: Int
-        get() = 18
+        get() = 27
 
     override fun getTitle(player: Player): String {
         return SettingMenuMessages.TITLE.asSafety(player.wrappedLocale)
     }
 
     init {
-        // 色々トグル設定(1..16)
-        ToggleSetting.values().forEachIndexed { index, display ->
-            var slotNum = index
-            //見栄えが悪いので7,8スロットにはボタンを置かない
-            if (index >= 7) {
-                slotNum += 2
-            }
-
-            registerButton(slotNum, object : Button {
-                override fun toShownItemStack(player: Player): ItemStack? {
-                    val itemStack = if (display.getToggle(player)) {
-                        ItemStack(Material.ENDER_EYE)
-                    } else {
-                        ItemStack(Material.ENDER_PEARL)
-                    }
-                    return itemStack.apply {
-                        setDisplayName(
-                            "${ChatColor.WHITE}${ChatColor.BOLD}" +
-                                    display.getName(player.wrappedLocale) + ": " +
-                                    if (display.getToggle(player)) {
-                                        "${ChatColor.GREEN}${ChatColor.BOLD}ON"
-                                    } else {
-                                        "${ChatColor.RED}${ChatColor.BOLD}OFF"
-                                    }
-                        )
-                        setLore(ToolSwitchMessages.CLICK_TO_TOGGLE.asSafety(player.wrappedLocale))
-                    }
-                }
-
-                val coolTimeSet = mutableSetOf<UUID>()
-
-                override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
-                    val uniqueId = player.uniqueId
-                    if (coolTimeSet.contains(uniqueId)) return false
-                    coolTimeSet.add(uniqueId)
-                    runTaskLater(5L) {
-                        coolTimeSet.remove(uniqueId)
-                    }
-                    display.toggle(player)
-                    PlayerSounds.TOGGLE.playOnly(player)
-                    reopen(player)
-                    player.updateDisplay(applyMainHand = true, applyOffHand = true)
-                    return true
-                }
-            })
-        }
+        // 設定のカテゴリー
+        registerButton(11, SettingButtons.DISPLAY_SETTING)
+        registerButton(13, SettingButtons.FUNCTION_SETTING)
+        registerButton(15, SettingButtons.NOTIFICATION_SETTING)
         // ツール切り替え設定
-        registerButton(17, SettingButtons.TOOL_SWITCH_SETTING)
+        registerButton(26, SettingButtons.TOOL_SWITCH_SETTING)
         // テクスチャ切り替え設定
         // 権利関連が不明のため無効化
         // registerButton(15, SettingButtons.TEXTURE)

--- a/src/main/kotlin/click/seichi/gigantic/menu/menus/setting/CategorySettingMenu.kt
+++ b/src/main/kotlin/click/seichi/gigantic/menu/menus/setting/CategorySettingMenu.kt
@@ -1,0 +1,80 @@
+package click.seichi.gigantic.menu.menus.setting
+
+import click.seichi.gigantic.extension.*
+import click.seichi.gigantic.item.Button
+import click.seichi.gigantic.item.items.menu.BackButton
+import click.seichi.gigantic.menu.Menu
+import click.seichi.gigantic.menu.menus.SettingMenu
+import click.seichi.gigantic.message.messages.menu.SettingMenuMessages
+import click.seichi.gigantic.message.messages.menu.ToolSwitchMessages
+import click.seichi.gigantic.player.ToggleSetting
+import click.seichi.gigantic.sound.sounds.PlayerSounds
+import org.bukkit.ChatColor
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.ItemStack
+import java.util.*
+
+class CategorySettingMenu(private val category: ToggleSetting.Category) : Menu() {
+    override val size: Int
+        get() = 27
+
+        override fun getTitle(player: Player): String {
+        return when (category) {
+            ToggleSetting.Category.DISPLAY -> SettingMenuMessages.DISPLAY_SETTINGS.asSafety(player.wrappedLocale)
+            ToggleSetting.Category.FUNCTION -> SettingMenuMessages.FUNCTION_SETTINGS.asSafety(player.wrappedLocale)
+            ToggleSetting.Category.NOTIFICATION -> SettingMenuMessages.NOTIFICATION_SETTINGS.asSafety(player.wrappedLocale)
+        }
+    }
+
+    init {
+        ToggleSetting.values()
+            .filter { it.category == category }
+            .forEachIndexed { index, setting ->
+                var slotNum = index
+                // 見栄えが悪いので18スロット以降にはボタンを置かない
+                if (index >= 18) return@forEachIndexed
+
+                registerButton(slotNum, object : Button {
+
+                    override fun toShownItemStack(player: Player): ItemStack? {
+                        val itemStack = if (setting.getToggle(player)) {
+                            ItemStack(Material.ENDER_EYE)
+                        } else {
+                            ItemStack(Material.ENDER_PEARL)
+                        }
+                        return itemStack.apply {
+                            setDisplayName(
+                                "${ChatColor.WHITE}${ChatColor.BOLD}" +
+                                    setting.getName(player.wrappedLocale) + ": " +
+                                    if (setting.getToggle(player)) {
+                                        "${ChatColor.GREEN}${ChatColor.BOLD}ON"
+                                    } else {
+                                        "${ChatColor.RED}${ChatColor.BOLD}OFF"
+                                    }
+                            )
+                            setLore(ToolSwitchMessages.CLICK_TO_TOGGLE.asSafety(player.wrappedLocale))
+                        }
+                    }
+
+                    val coolTimeSet = mutableSetOf<UUID>()
+
+                    override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
+                        val uniqueId = player.uniqueId
+                        if (coolTimeSet.contains(uniqueId)) return false
+                        coolTimeSet.add(uniqueId)
+                        runTaskLater(5L) {
+                            coolTimeSet.remove(uniqueId)
+                        }
+                        setting.toggle(player)
+                        PlayerSounds.TOGGLE.playOnly(player)
+                        reopen(player)
+                        player.updateDisplay(applyMainHand = true, applyOffHand = true)
+                        return true
+                    }
+                })
+            }
+        registerButton(18, BackButton(this, SettingMenu))
+    }
+}

--- a/src/main/kotlin/click/seichi/gigantic/message/Tips.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/Tips.kt
@@ -131,6 +131,12 @@ enum class Tips(
                         "${ChatColor.WHITE}" +
                         "詳細設定からランキングの更新時に通知を受け取ることができるぞ！"
             ), 2L)),
+    HIDE_TIPS(LinedChatMessage(ChatMessageProtocol.CHAT,
+            LocalizedText(
+                Locale.JAPANESE to Defaults.TIPS_PREFIX +
+                        "${ChatColor.WHITE}" +
+                        "メニューの詳細設定→通知設定からTIPSをオフにできるぞ！"
+            ), 2L)),
     ;
 
     fun sendTo(player: Player) {

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/BagMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/BagMessages.kt
@@ -92,26 +92,35 @@ object BagMessages {
     val DISPLAY_SETTING = LocalizedText(
             Locale.JAPANESE to "表示設定"
     )
-    val DISPLAY_SETTING_LORE = LocalizedText(
-            Locale.JAPANESE to "${ChatColor.LIGHT_PURPLE}" +
-            //TODO: 実装後、適切な説明に変更
-                    "未実装"
+    val DISPLAY_SETTING_LORE_1 = LocalizedText(
+            Locale.JAPANESE to "${ChatColor.GRAY}" +
+                    "各種表示に関する設定"
+    )
+    val DISPLAY_SETTING_LORE_2 = LocalizedText(
+        Locale.JAPANESE to "${ChatColor.GRAY}" +
+                "(獲得経験値・コンボなど)"
     )
     val FUNCTION_SETTING = LocalizedText(
             Locale.JAPANESE to "機能設定"
     )
-    val FUNCTION_SETTING_LORE = LocalizedText(
-            Locale.JAPANESE to "${ChatColor.LIGHT_PURPLE}" +
-            //TODO: 実装後、適切な説明に変更
-                    "未実装"
+    val FUNCTION_SETTING_LORE_1 = LocalizedText(
+        Locale.JAPANESE to "${ChatColor.GRAY}" +
+                "各種機能に関する設定"
+    )
+    val FUNCTION_SETTING_LORE_2 = LocalizedText(
+        Locale.JAPANESE to "${ChatColor.GRAY}" +
+                "(暗視・交感中表示など)"
     )
     val NOTIFICATION_SETTING = LocalizedText(
             Locale.JAPANESE to "通知設定"
     )
-    val NOTIFICATION_SETTING_LORE = LocalizedText(
-            Locale.JAPANESE to "${ChatColor.LIGHT_PURPLE}" +
-            //TODO: 実装後、適切な説明に変更
-                    "未実装"
+    val NOTIFICATION_SETTING_LORE_1 = LocalizedText(
+        Locale.JAPANESE to "${ChatColor.GRAY}" +
+                "チャットに送信される要素の設定"
+    )
+    val NOTIFICATION_SETTING_LORE_2 = LocalizedText(
+        Locale.JAPANESE to "${ChatColor.GRAY}" +
+                "(ランキング更新・Tipsなど)"
     )
     val VOTE_BONUS = LocalizedText(
             Locale.JAPANESE to "投票特典"

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/BagMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/BagMessages.kt
@@ -89,7 +89,30 @@ object BagMessages {
             Locale.JAPANESE to "${ChatColor.LIGHT_PURPLE}" +
                     "\"f\" キー を押してツールを変更"
     )
-
+    val DISPLAY_SETTING = LocalizedText(
+            Locale.JAPANESE to "表示設定"
+    )
+    val DISPLAY_SETTING_LORE = LocalizedText(
+            Locale.JAPANESE to "${ChatColor.LIGHT_PURPLE}" +
+            //TODO: 実装後、適切な説明に変更
+                    "未実装"
+    )
+    val FUNCTION_SETTING = LocalizedText(
+            Locale.JAPANESE to "機能設定"
+    )
+    val FUNCTION_SETTING_LORE = LocalizedText(
+            Locale.JAPANESE to "${ChatColor.LIGHT_PURPLE}" +
+            //TODO: 実装後、適切な説明に変更
+                    "未実装"
+    )
+    val NOTIFICATION_SETTING = LocalizedText(
+            Locale.JAPANESE to "通知設定"
+    )
+    val NOTIFICATION_SETTING_LORE = LocalizedText(
+            Locale.JAPANESE to "${ChatColor.LIGHT_PURPLE}" +
+            //TODO: 実装後、適切な説明に変更
+                    "未実装"
+    )
     val VOTE_BONUS = LocalizedText(
             Locale.JAPANESE to "投票特典"
     )

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/menu/SettingMenuMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/menu/SettingMenuMessages.kt
@@ -11,5 +11,13 @@ object SettingMenuMessages {
     val TITLE = LocalizedText(
             Locale.JAPANESE to "詳細設定"
     )
-
+    val DISPLAY_SETTINGS = LocalizedText(
+        Locale.JAPANESE to "表示設定"
+    )
+    val FUNCTION_SETTINGS = LocalizedText(
+        Locale.JAPANESE to "機能設定"
+    )
+    val NOTIFICATION_SETTINGS = LocalizedText(
+        Locale.JAPANESE to "通知設定"
+    )
 }

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -85,7 +85,8 @@ enum class ToggleSetting(
         12, LocalizedText(
             Locale.JAPANESE to "コンボランキングの通知"
         ), true, Category.NOTIFICATION
-    );
+    ),
+    ;
 
     fun getName(locale: Locale) = localizedName.asSafety(locale)
 

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -75,6 +75,11 @@ enum class ToggleSetting(
         11, LocalizedText(
             Locale.JAPANESE to "TIPSの通知"
         ), true, Category.NOTIFICATION
+    ),
+    COMBO_RANKING_NOTIFICATION(
+        12, LocalizedText(
+            Locale.JAPANESE to "コンボランキングの通知"
+        ), true, Category.NOTIFICATION
     );
 
     fun getName(locale: Locale) = localizedName.asSafety(locale)

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -13,53 +13,69 @@ import java.util.*
 enum class ToggleSetting(
         val id: Int,
         private val localizedName: LocalizedText,
-        val default: Boolean
+        val default: Boolean,
+        val category: Category
 ) {
     GAIN_EXP(
         0, LocalizedText(
             Locale.JAPANESE to "獲得経験値表示"
-        ), false
+        ), false, Category.DISPLAY
     ),
     UNDER_PLAYER(
         1, LocalizedText(
             Locale.JAPANESE to "低い位置のブロック破壊警告"
-        ), true
+        ), true, Category.FUNCTION
     ),
     COMBO(
         2, LocalizedText(
             Locale.JAPANESE to "コンボ表示"
-        ), true
+        ), true, Category.DISPLAY
     ),
     AUTORCH(
         3, LocalizedText(
             Locale.JAPANESE to "自動松明設置"
-        ), true
+        ), true, Category.FUNCTION
     ),
     NIGHT_VISION(
         4, LocalizedText(
             Locale.JAPANESE to "暗視"
-        ), true
+        ), true, Category.FUNCTION
     ),
     SEE_OTHER_WILL_SPIRIT(
         5, LocalizedText(
             Locale.JAPANESE to "他の人の意志の表示"
-    ), true),
+        ), true, Category.DISPLAY
+    ),
     COMBO_POSITION_FIX(
         6, LocalizedText(
             Locale.JAPANESE to "コンボ表示位置の修正"
-        ), true
+        ), true, Category.FUNCTION
     ),
     SEE_WILL_BOSSBAR(
         7, LocalizedText(
             Locale.JAPANESE to "意志の交感中表示"
-        ), true
+        ), true, Category.FUNCTION
     ),
     UPDATE_RANKING(
         8, LocalizedText(
             Locale.JAPANESE to "ランキングの更新通知"
-        ), false
+        ), false, Category.NOTIFICATION
     ),
-    ;
+    MANA_HP_DISPLAY(
+        9, LocalizedText(
+            Locale.JAPANESE to "マナ回復・HP回復の表示"
+        ), true, Category.DISPLAY
+    ),
+    SCOREBOARD_MANA(
+        10, LocalizedText(
+            Locale.JAPANESE to "スコアボードにマナの情報を表示"
+        ), true, Category.DISPLAY
+    ),
+    TIPS_NOTIFICATION(
+        11, LocalizedText(
+            Locale.JAPANESE to "TIPSの通知"
+        ), true, Category.NOTIFICATION
+    );
 
     fun getName(locale: Locale) = localizedName.asSafety(locale)
 
@@ -67,4 +83,7 @@ enum class ToggleSetting(
 
     fun toggle(player: Player) = player.transform(Keys.TOGGLE_SETTING_MAP.getValue(this)) { !it }
 
+    enum class Category {
+        DISPLAY, FUNCTION, NOTIFICATION
+    }
 }

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -71,6 +71,11 @@ enum class ToggleSetting(
             Locale.JAPANESE to "スコアボードにマナの情報を表示"
         ), false, Category.DISPLAY
     ),
+    SCOREBOARD_TOTAL_EXP(
+        10, LocalizedText(
+            Locale.JAPANESE to "スコアボードに総経験値量の情報を表示"
+        ), false, Category.DISPLAY
+    ),
     TIPS_NOTIFICATION(
         11, LocalizedText(
             Locale.JAPANESE to "TIPSの通知"

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -69,7 +69,7 @@ enum class ToggleSetting(
     SCOREBOARD_MANA(
         10, LocalizedText(
             Locale.JAPANESE to "スコアボードにマナの情報を表示"
-        ), true, Category.DISPLAY
+        ), false, Category.DISPLAY
     ),
     TIPS_NOTIFICATION(
         11, LocalizedText(

--- a/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
@@ -135,10 +135,12 @@ object Skills {
                 val diff = nextHealth - p.health
                 p.health = nextHealth
 
-                SkillAnimations.HEAL.absorb(p, block.centralLocation)
-                PopUp(SimpleAnimation, block.centralLocation.add(0.0, 0.2, 0.0), PopUpMessages.HEAL(diff))
-                    .pop()
-                SkillSounds.HEAL.play(block.centralLocation)
+                if (ToggleSetting.MANA_HP_DISPLAY.getToggle(p)) {
+                    SkillAnimations.HEAL.absorb(p, block.centralLocation)
+                    PopUp(SimpleAnimation, block.centralLocation.add(0.0, 0.2, 0.0), PopUpMessages.HEAL(diff))
+                        .pop()
+                    SkillSounds.HEAL.play(block.centralLocation)
+                }
             }
         }
 

--- a/src/main/kotlin/click/seichi/gigantic/player/spell/Spells.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/spell/Spells.kt
@@ -12,6 +12,7 @@ import click.seichi.gigantic.message.messages.PlayerMessages
 import click.seichi.gigantic.message.messages.PopUpMessages
 import click.seichi.gigantic.player.Defaults
 import click.seichi.gigantic.player.Invokable
+import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.popup.PopUp
 import click.seichi.gigantic.popup.SimpleAnimation
 import click.seichi.gigantic.sound.sounds.SpellSounds
@@ -40,10 +41,15 @@ object Spells {
                     wrappedAmount = it.increase(it.max.divide(100.toBigDecimal(), 10, RoundingMode.HALF_UP).times(Config.SPELL_STELLA_CLAIR_RATIO.toBigDecimal()))
                 }
 
-                SpellAnimations.STELLA_CLAIR.absorb(p, block.centralLocation)
-                PopUp(SimpleAnimation, block.centralLocation.add(0.0, 0.2, 0.0), PopUpMessages.STELLA_CLAIR(wrappedAmount))
-                        .pop()
-                SpellSounds.STELLA_CLAIR.play(block.centralLocation)
+                if (ToggleSetting.MANA_HP_DISPLAY.getToggle(p)) {
+                    SpellAnimations.STELLA_CLAIR.absorb(p, block.centralLocation)
+                    PopUp(
+                        SimpleAnimation,
+                        block.centralLocation.add(0.0, 0.2, 0.0),
+                        PopUpMessages.STELLA_CLAIR(wrappedAmount)
+                    ).pop()
+                    SpellSounds.STELLA_CLAIR.play(block.centralLocation)
+                }
 
                 PlayerMessages.MANA_DISPLAY(p.mana, p.maxMana).sendTo(p)
 

--- a/src/main/kotlin/click/seichi/gigantic/ranking/Combo30minRanking.kt
+++ b/src/main/kotlin/click/seichi/gigantic/ranking/Combo30minRanking.kt
@@ -2,6 +2,8 @@ package click.seichi.gigantic.ranking
 
 import click.seichi.gigantic.Gigantic
 import click.seichi.gigantic.extension.combo
+import click.seichi.gigantic.extension.info
+import click.seichi.gigantic.player.ToggleSetting
 import org.bukkit.Bukkit
 import org.bukkit.ChatColor
 import org.bukkit.scheduler.BukkitRunnable
@@ -66,9 +68,11 @@ class Combo30minRanking {
                 threePlayerCombo == playerCombo -> threePlayerName += ", $playerName"
             }
         }
-
+        info("COMBOランキング")
         // 結果通知用
-        Bukkit.getOnlinePlayers().forEach { player ->
+        Bukkit.getOnlinePlayers()
+            .filter { ToggleSetting.COMBO_RANKING_NOTIFICATION.getToggle(it) }
+            .forEach { player ->
             player.sendMessage(
                     "${ChatColor.YELLOW}${ChatColor.BOLD}☆☆☆☆☆☆☆☆" +
                             "${ChatColor.AQUA}${ChatColor.BOLD}定期コンボ量ランキング発表！" +

--- a/src/main/kotlin/click/seichi/gigantic/ranking/Combo30minRanking.kt
+++ b/src/main/kotlin/click/seichi/gigantic/ranking/Combo30minRanking.kt
@@ -68,7 +68,6 @@ class Combo30minRanking {
                 threePlayerCombo == playerCombo -> threePlayerName += ", $playerName"
             }
         }
-        info("COMBOランキング")
         // 結果通知用
         Bukkit.getOnlinePlayers()
             .filter { ToggleSetting.COMBO_RANKING_NOTIFICATION.getToggle(it) }

--- a/src/main/kotlin/click/seichi/gigantic/ranking/Combo30minRanking.kt
+++ b/src/main/kotlin/click/seichi/gigantic/ranking/Combo30minRanking.kt
@@ -2,7 +2,6 @@ package click.seichi.gigantic.ranking
 
 import click.seichi.gigantic.Gigantic
 import click.seichi.gigantic.extension.combo
-import click.seichi.gigantic.extension.info
 import click.seichi.gigantic.player.ToggleSetting
 import org.bukkit.Bukkit
 import org.bukkit.ChatColor

--- a/src/main/kotlin/click/seichi/gigantic/sidebar/bars/MainBar.kt
+++ b/src/main/kotlin/click/seichi/gigantic/sidebar/bars/MainBar.kt
@@ -3,9 +3,11 @@ package click.seichi.gigantic.sidebar.bars
 import click.seichi.gigantic.acheivement.Achievement
 import click.seichi.gigantic.extension.getWrappedExp
 import click.seichi.gigantic.extension.mana
+import click.seichi.gigantic.extension.maxMana
 import click.seichi.gigantic.extension.wrappedLevel
 import click.seichi.gigantic.player.Defaults
 import click.seichi.gigantic.player.ExpReason
+import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.sidebar.SideBar
 import click.seichi.gigantic.util.SideBarRow
 import org.bukkit.ChatColor
@@ -135,7 +137,9 @@ object MainBar : SideBar("info") {
                         "${ChatColor.WHITE}${info.manaPerMinute.setScale(2, RoundingMode.HALF_UP)}/分"
                     }
         }
-
+        if (ToggleSetting.SCOREBOARD_MANA.getToggle(player)){
+            map[SideBarRow.EIGHT] = "           ${ChatColor.DARK_AQUA}${player.mana.coerceAtLeast(BigDecimal.ZERO).setScale(1, RoundingMode.HALF_UP)}/${player.maxMana}"
+        }
 
         if (Achievement.MANA_STONE.isGranted(player))
             map[SideBarRow.THIRTEEN] = "${Defaults.SIDEBAR_HIDE_COLOR}___"

--- a/src/main/kotlin/click/seichi/gigantic/sidebar/bars/MainBar.kt
+++ b/src/main/kotlin/click/seichi/gigantic/sidebar/bars/MainBar.kt
@@ -1,14 +1,12 @@
 package click.seichi.gigantic.sidebar.bars
 
 import click.seichi.gigantic.acheivement.Achievement
-import click.seichi.gigantic.extension.getWrappedExp
-import click.seichi.gigantic.extension.mana
-import click.seichi.gigantic.extension.maxMana
-import click.seichi.gigantic.extension.wrappedLevel
+import click.seichi.gigantic.extension.*
 import click.seichi.gigantic.player.Defaults
 import click.seichi.gigantic.player.ExpReason
 import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.sidebar.SideBar
+import click.seichi.gigantic.util.NumberUtils.commaSeparated
 import click.seichi.gigantic.util.SideBarRow
 import org.bukkit.ChatColor
 import org.bukkit.entity.Player
@@ -56,9 +54,14 @@ object MainBar : SideBar("info") {
         map[SideBarRow.ONE] = "${ChatColor.GREEN}${ChatColor.BOLD} レベル : " +
                 "${ChatColor.WHITE}${info.level}"
 
-        map[SideBarRow.TWO] = "${Defaults.SIDEBAR_HIDE_COLOR}_"
+        if (ToggleSetting.SCOREBOARD_TOTAL_EXP.getToggle(player)) {
+            map[SideBarRow.TWO] = "${ChatColor.GREEN}${ChatColor.BOLD}総経験値: " +
+                "${ChatColor.WHITE}${player.wrappedExp.setScale(0, RoundingMode.FLOOR).commaSeparated()}"
+        }
 
-        map[SideBarRow.THREE] = "${ChatColor.GREEN}${ChatColor.BOLD}通常破壊: " +
+        map[SideBarRow.THREE] = "${Defaults.SIDEBAR_HIDE_COLOR}_"
+
+        map[SideBarRow.FOUR] = "${ChatColor.GREEN}${ChatColor.BOLD}通常破壊: " +
                 if (info.mineBlockPerMinute >= 1000000000.toBigDecimal()) {
                     "${ChatColor.RED}測定不能"
                 } else if (info.mineBlockPerMinute >= 1000000.toBigDecimal()) {
@@ -70,7 +73,7 @@ object MainBar : SideBar("info") {
                 }
 
         if (Achievement.SPELL_MULTI_BREAK.isGranted(player)) {
-            map[SideBarRow.FOUR] = "${ChatColor.DARK_AQUA}${ChatColor.BOLD}魔法破壊: " +
+            map[SideBarRow.FIVE] = "${ChatColor.DARK_AQUA}${ChatColor.BOLD}魔法破壊: " +
                     if (info.multiBlockPerMinute >= 1000000000.toBigDecimal()) {
                         "${ChatColor.RED}測定不能"
                     } else if (info.multiBlockPerMinute >= 1000000.toBigDecimal()) {
@@ -84,7 +87,7 @@ object MainBar : SideBar("info") {
 
 
         if (Achievement.FIRST_RELIC.isGranted(player)) {
-            map[SideBarRow.FIVE] = "${ChatColor.GOLD}${ChatColor.BOLD}レリック: " +
+            map[SideBarRow.SIX] = "${ChatColor.GOLD}${ChatColor.BOLD}レリック: " +
                 if (info.relicBonusPerMinute >= (99999.99).toBigDecimal()) {
                     when {
                         info.relicBonusPerMinute >= 1000000000.toBigDecimal() -> {
@@ -110,10 +113,10 @@ object MainBar : SideBar("info") {
                 }
         }        
 
-        map[SideBarRow.SIX] = "${Defaults.SIDEBAR_HIDE_COLOR}__"
+        map[SideBarRow.SEVEN] = "${Defaults.SIDEBAR_HIDE_COLOR}__"
 
         if (Achievement.MANA_STONE.isGranted(player)) {
-            map[SideBarRow.SEVEN] = "${ChatColor.AQUA}${ChatColor.BOLD}  マナ  : " +
+            map[SideBarRow.EIGHT] = "${ChatColor.AQUA}${ChatColor.BOLD}  マナ  : " +
                     if (info.manaPerMinute >= (99999.99).toBigDecimal()) {
                         when {
                             info.relicBonusPerMinute >= 1000000000.toBigDecimal() -> {
@@ -138,13 +141,13 @@ object MainBar : SideBar("info") {
                     }
         }
         if (ToggleSetting.SCOREBOARD_MANA.getToggle(player)){
-            map[SideBarRow.EIGHT] = "           ${ChatColor.DARK_AQUA}${player.mana.coerceAtLeast(BigDecimal.ZERO).setScale(1, RoundingMode.HALF_UP)}/${player.maxMana}"
+            map[SideBarRow.NINE] = "           ${ChatColor.DARK_AQUA}${player.mana.coerceAtLeast(BigDecimal.ZERO).setScale(1, RoundingMode.HALF_UP)}/${player.maxMana}"
         }
 
         if (Achievement.MANA_STONE.isGranted(player))
-            map[SideBarRow.THIRTEEN] = "${Defaults.SIDEBAR_HIDE_COLOR}___"
+            map[SideBarRow.TEN] = "${Defaults.SIDEBAR_HIDE_COLOR}___"
 
-        map[SideBarRow.FOURTEEN] = "${ChatColor.YELLOW}" +
+        map[SideBarRow.ELEVEN] = "${ChatColor.YELLOW}" +
                 "  seichi-haru.pgw.jp  "
 
         return map

--- a/src/main/kotlin/click/seichi/gigantic/util/NumberUtils.kt
+++ b/src/main/kotlin/click/seichi/gigantic/util/NumberUtils.kt
@@ -1,0 +1,12 @@
+package click.seichi.gigantic.util
+
+import java.math.BigDecimal
+import java.text.NumberFormat
+import java.util.Locale
+
+object NumberUtils {
+    fun BigDecimal.commaSeparated(): String {
+        val formatter = NumberFormat.getNumberInstance(Locale.US)
+        return formatter.format(this)
+    }
+}


### PR DESCRIPTION
このプルリクエストでは、プロジェクトの設定メニューおよび通知システムにいくつかの新機能と改善を導入します。主な変更点として、新しい設定カテゴリの追加、新しい `CategorySettingMenu` クラスの作成、およびこれらの新設定をサポートするためのさまざまなコンポーネントの更新が含まれます。

### 新機能:
* **新しい設定カテゴリ:**
  * `SettingButtons` オブジェクトに `DISPLAY_SETTING`、`FUNCTION_SETTING`、および `NOTIFICATION_SETTING` ボタンを追加しました。これらのボタンにより、メインの設定メニューからさまざまなカテゴリの設定にアクセスできるようになります。
  * 各カテゴリ内の設定の表示および操作を処理するための新しい `CategorySettingMenu` クラスを導入しました。

### 既存機能の改善:
* **設定メニューの更新:**
  * 新しい設定カテゴリを収容するために、`SettingMenu` のスロット数を 18 から 27 に増加させました。
  * 新しい設定カテゴリボタンを `SettingMenu` に登録しました。

* **通知および表示設定:**
  * 新しい設定カテゴリとその説明のためのローカライズされたメッセージを追加しました。
  * 設定をカテゴリにグループ化できるようにするため、`ToggleSetting` 列挙型に `Category` 属性を追加しました。

### コードベースの改善:
* **条件付き表示ロジック:**
  * `TIPS_NOTIFICATION` や `MANA_HP_DISPLAY` 設定など、ユーザー設定に基づいて通知やアニメーションを表示する条件付きチェックを追加しました。

これらの変更により、設定の細かい制御が可能になり、設定の整理およびアクセス性が向上することで、ユーザー体験の向上を目指します。


close #27 