### PR TITLE
feat: DiscordのWebhookを使用してレベル達成通知を送信する機能を追加 (#30)

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/acheivement/Achievement.kt
+++ b/src/main/kotlin/click/seichi/gigantic/acheivement/Achievement.kt
@@ -5,6 +5,7 @@ import click.seichi.gigantic.belt.Belt
 import click.seichi.gigantic.cache.key.Keys
 import click.seichi.gigantic.config.DebugConfig
 import click.seichi.gigantic.extension.*
+import click.seichi.gigantic.message.DiscordWebhookNotifier
 import click.seichi.gigantic.message.LinedChatMessage
 import click.seichi.gigantic.message.Message
 import click.seichi.gigantic.message.messages.AchievementMessages
@@ -57,8 +58,9 @@ enum class Achievement(
             priority = UpdatePriority.LOWEST),
     TUTORIAL(5, {
         it.wrappedLevel >= 200
-    }, broadcastMessage = { AchievementMessages.TUTORIAL_ALL(it) }
-            , broadcastSound = PlayerSounds.ACHIEVE_TUTORIAL),
+    }, action = {DiscordWebhookNotifier.sendLevelNotification(it.name,200)}
+        , broadcastMessage = { AchievementMessages.TUTORIAL_ALL(it) }
+        , broadcastSound = PlayerSounds.ACHIEVE_TUTORIAL),
     FIRST_PRE_SENSE(6, {
         Will.values().firstOrNull { will -> it.isProcessed(will) } != null
     }, grantMessage = AchievementMessages.FIRST_PRE_SENSE),

--- a/src/main/kotlin/click/seichi/gigantic/config/Config.kt
+++ b/src/main/kotlin/click/seichi/gigantic/config/Config.kt
@@ -63,4 +63,6 @@ object Config : SimpleConfiguration("config") {
 
     val SPELL_LUNA_FLEX_MANA_PER_DEGREE by lazy { getDouble("spell.luna_flex.mana_per_degree") }
 
+    val WEBHOOK_DISCORD_LEVEL_NOTIFICATION_URL by lazy { getString("webhook.discord.level_notification_url") }
+
 }

--- a/src/main/kotlin/click/seichi/gigantic/message/DiscordWebhookNotifier.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/DiscordWebhookNotifier.kt
@@ -1,0 +1,38 @@
+package click.seichi.gigantic.message
+
+import click.seichi.gigantic.config.Config
+import click.seichi.gigantic.extension.warning
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+
+object DiscordWebhookNotifier {
+    private val webhookUrl: String? = Config.WEBHOOK_DISCORD_LEVEL_NOTIFICATION_URL
+
+    fun sendLevelNotification(name: String, unlockLevel: Int) {
+        if (webhookUrl == null) {
+            warning("webhookUrlが存在しなかったため送信できませんでした。")
+            return
+        }
+        val message = "<@&1322598582444101662>\\r【速報】${name}さんがLv${unlockLevel}を達成しました。\\rおめでとうございます！"
+        val payload = "{\"content\": \"$message\"}"
+
+        try {
+            val url = URL(webhookUrl)
+            val connection = url.openConnection() as HttpURLConnection
+            connection.requestMethod = "POST"
+            connection.doOutput = true
+            connection.setRequestProperty("Content-Type", "application/json")
+            connection.setRequestProperty("User-Agent", "SeichiHaruUnofficialPlugin (Ubuntu 20.04.6 LTS; Kotlin/1.5)")
+
+            connection.outputStream.use { os ->
+                val input = payload.toByteArray(StandardCharsets.UTF_8)
+                os.write(input, 0, input.size)
+            }
+
+            connection.inputStream.use { it.readBytes() }
+        } catch (e: Exception) {
+            warning("Level達成通知が送信できませんでした。: ${e.message}")
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,10 @@ resource:
   default: "Spring_Texture_ver1.2.zip"
   no_particle: "Spring_Texture_No_Particle_ver1.2.zip"
 
+webhook:
+  discord:
+    level_notification_url: ""
+
 tips:
   interval: 5
 


### PR DESCRIPTION
このプルリクエストでは、レベル達成通知をDiscordのWebhookに送信する新機能を導入します。主な変更点は、Discord Webhookの新しい設定の追加、`DiscordWebhookNotifier` クラスの実装、およびこの通知機能を使用するように `Achievement` クラスを変更したことです。

### 新機能: Discord Webhook通知

* `Achievement.kt`: `DiscordWebhookNotifier` のインポートを追加し、`TUTORIAL` 達成で `DiscordWebhookNotifier` を使用して通知を送信するように変更しました。

### 設定の変更

* `Config.kt`: 新しい設定プロパティを追加しました。
* `config.yml`: Discord Webhook用の新しいセクションを追加しました。

### Discord Webhook通知機能の実装

* `DiscordWebhookNotifier.kt`: 設定されたDiscord Webhookにレベル達成通知を送信するためのオブジェクトを実装しました。


close #30