### PR TITLE
feat: 整地レベル200以降も100刻みで通知するように (#29)

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/acheivement/Achievement.kt
+++ b/src/main/kotlin/click/seichi/gigantic/acheivement/Achievement.kt
@@ -59,7 +59,7 @@ enum class Achievement(
     TUTORIAL(5, {
         it.wrappedLevel >= 200
     }, action = {DiscordWebhookNotifier.sendLevelNotification(it.name,200)}
-        , broadcastMessage = { AchievementMessages.TUTORIAL_ALL(it) }
+        , broadcastMessage = { AchievementMessages.LEVEL_UP_ALL(it,200) }
         , broadcastSound = PlayerSounds.ACHIEVE_TUTORIAL),
     FIRST_PRE_SENSE(6, {
         Will.values().firstOrNull { will -> it.isProcessed(will) } != null

--- a/src/main/kotlin/click/seichi/gigantic/listener/PlayerMonitor.kt
+++ b/src/main/kotlin/click/seichi/gigantic/listener/PlayerMonitor.kt
@@ -15,6 +15,8 @@ import click.seichi.gigantic.event.events.LevelUpEvent
 import click.seichi.gigantic.event.events.RelicGenerateEvent
 import click.seichi.gigantic.event.events.SenseEvent
 import click.seichi.gigantic.extension.*
+import click.seichi.gigantic.message.DiscordWebhookNotifier
+import click.seichi.gigantic.message.messages.AchievementMessages
 import click.seichi.gigantic.message.messages.GiganticEventMessages
 import click.seichi.gigantic.message.messages.LoginMessages
 import click.seichi.gigantic.message.messages.PlayerMessages
@@ -147,6 +149,12 @@ class PlayerMonitor : Listener {
         PlayerSounds.LEVEL_UP.play(player.location)
 
         Achievement.update(event.player)
+
+        if (event.level !in 1..200 && event.level % 100 == 0) {
+            AchievementMessages.LEVEL_UP_ALL(event.player,event.level).broadcast()
+            PlayerSounds.LEVEL_UP_ANNOUNCEMENT.broadcast()
+            DiscordWebhookNotifier.sendLevelNotification(event.player.name,event.level)
+        }
 
         player.manipulate(CatalogPlayerCache.MANA) {
             val prevMax = it.max

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/AchievementMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/AchievementMessages.kt
@@ -17,7 +17,7 @@ import java.util.*
  */
 object AchievementMessages {
 
-    val TUTORIAL_ALL = { player: Player ->
+    val LEVEL_UP_ALL = { player: Player , level: Int->
         ChatMessage(ChatMessageProtocol.CHAT,
                 LocalizedText(
                         Locale.JAPANESE to "${ChatColor.WHITE}${ChatColor.BOLD}" +
@@ -27,7 +27,7 @@ object AchievementMessages {
                                 "${ChatColor.WHITE}" +
                                 "が" +
                                 "${ChatColor.LIGHT_PURPLE}" +
-                                " Lv200 " +
+                                " Lv$level " +
                                 "${ChatColor.WHITE}" +
                                 "を達成しました。" +
                                 "おめでとうございます!"

--- a/src/main/kotlin/click/seichi/gigantic/sound/sounds/PlayerSounds.kt
+++ b/src/main/kotlin/click/seichi/gigantic/sound/sounds/PlayerSounds.kt
@@ -17,6 +17,13 @@ object PlayerSounds {
             volume = 0.5F
     )
 
+    val LEVEL_UP_ANNOUNCEMENT = DetailedSound(
+        Sound.ITEM_TOTEM_USE,
+        SoundCategory.PLAYERS,
+        pitch = 0.7f,
+        volume = 1f
+    )
+
     val OBTAIN_EXP = { combo: Long ->
         DetailedSound(
                 Sound.ENTITY_EXPERIENCE_ORB_PICKUP,


### PR DESCRIPTION
このプルリクエストには、特にレベルアップの通知と関連するサウンドに焦点を当てた、達成通知システムに関するいくつかの変更が含まれています。主な変更内容は、チュートリアル達成のメッセージの更新、新しいインポートの追加、および新しいレベルアップ通知とサウンドの導入です。

### 達成通知の更新:

* `src/main/kotlin/click/seichi/gigantic/acheivement/Achievement.kt`: チュートリアル達成の放送メッセージを、`LEVEL_UP_ALL` にレベルパラメータを使用するように変更しました。
* `src/main/kotlin/click/seichi/gigantic/message/messages/AchievementMessages.kt`: `TUTORIAL_ALL` を `LEVEL_UP_ALL` に置き換え、達成した特定のレベルを含むようにメッセージを更新しました。

### 新しいレベルアップ通知とサウンド:

* `src/main/kotlin/click/seichi/gigantic/listener/PlayerMonitor.kt`: レベル200を超える100レベルごとに、レベルアップメッセージを放送し、サウンドを再生し、Discord通知を送信するチェックを追加しました。
* `src/main/kotlin/click/seichi/gigantic/sound/sounds/PlayerSounds.kt`: レベルアップ通知用の新しいサウンド `LEVEL_UP_ANNOUNCEMENT` を導入しました。

### 追加されたインポート:

* `src/main/kotlin/click/seichi/gigantic/listener/PlayerMonitor.kt`: `DiscordWebhookNotifier` と `AchievementMessages` のインポートを追加しました。
