### PR TITLE
fix: `菌糸だらけのツルハシ`の適用対象を青氷->キノコ島の海岸に修正

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/relic/Relic.kt
+++ b/src/main/kotlin/click/seichi/gigantic/relic/Relic.kt
@@ -756,7 +756,7 @@ enum class Relic(
             itemStackOf(Material.QUARTZ)
     ) {
         override fun isBonusTarget(block: Block): Boolean {
-            return block.type == Material.BLUE_ICE
+            return block.biome == Biome.MUSHROOM_FIELD_SHORE
         }
     },
     ACID_GEAR(


### PR DESCRIPTION
close #16 

## このPRの変更点と理由
- レリック「菌糸だらけのツルハシ」で、適用対象が青氷となっている問題について修正
- ボーナス適用対象を青氷からキノコ島の海岸に修正

## 補足
Loreに記載されている条件
![image](https://github.com/user-attachments/assets/cc482a2a-0bb2-4863-b014-6bbafe7719f7)
