### PR TITLE
feat: 複数の選択肢を持つ設定の追加・レリックの一括生成

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/Gigantic.kt
+++ b/src/main/kotlin/click/seichi/gigantic/Gigantic.kt
@@ -187,6 +187,7 @@ class Gigantic : JavaPlugin() {
                     UserHomeTable,
                     UserMuteTable,
                     UserToggleTable,
+                    UserSettingTable,
                     // product,
                     PurchaseHistoryTable,
                     //ranking

--- a/src/main/kotlin/click/seichi/gigantic/cache/cache/PlayerCache.kt
+++ b/src/main/kotlin/click/seichi/gigantic/cache/cache/PlayerCache.kt
@@ -159,6 +159,9 @@ class PlayerCache(private val uniqueId: UUID, private val playerName: String) : 
             Keys.TOGGLE_SETTING_MAP.forEach { (_, key) ->
                 offer(key, key.read(entity))
             }
+            Keys.SETTING_MAP.forEach { (_, key) ->
+                offer(key, key.read(entity))
+            }
         }
     }
 
@@ -274,6 +277,9 @@ class PlayerCache(private val uniqueId: UUID, private val playerName: String) : 
                 key.store(entity, getOrDefault(key))
             }
             Keys.TOGGLE_SETTING_MAP.forEach { (_, key) ->
+                key.store(entity, getOrDefault(key))
+            }
+            Keys.SETTING_MAP.forEach { (_, key) ->
                 key.store(entity, getOrDefault(key))
             }
 

--- a/src/main/kotlin/click/seichi/gigantic/cache/key/Keys.kt
+++ b/src/main/kotlin/click/seichi/gigantic/cache/key/Keys.kt
@@ -1138,6 +1138,27 @@ object Keys {
         }
     }.toMap()
 
+    val SETTING_MAP: Map<Setting, DatabaseKey<PlayerCache, Int, UserEntity>> = Setting.values().map { display ->
+        display to object : DatabaseKey<PlayerCache, Int, UserEntity> {
+            override val default: Int
+                get() = 0
+
+            override fun read(entity: UserEntity): Int {
+                val userSetting = entity.userSettingMap.getValue(display)
+                return userSetting.value
+            }
+
+            override fun store(entity: UserEntity, value: Int) {
+                val userSetting = entity.userSettingMap.getValue(display)
+                userSetting.value = value
+            }
+
+            override fun satisfyWith(value: Int): Boolean {
+                return true
+            }
+        }
+    }.toMap()
+
     val TITLE = object : Key<PlayerCache, String?> {
         override val default: String?
             get() = null

--- a/src/main/kotlin/click/seichi/gigantic/database/UserEntity.kt
+++ b/src/main/kotlin/click/seichi/gigantic/database/UserEntity.kt
@@ -8,6 +8,7 @@ import click.seichi.gigantic.database.table.PurchaseHistoryTable
 import click.seichi.gigantic.database.table.user.*
 import click.seichi.gigantic.monster.SoulMonster
 import click.seichi.gigantic.player.ExpReason
+import click.seichi.gigantic.player.Setting
 import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.quest.Quest
 import click.seichi.gigantic.relic.Relic
@@ -110,6 +111,16 @@ class UserEntity(uniqueId: UUID, playerName: String) {
             user = this@UserEntity.user
             toggleId = toggleSetting.id
             toggle = toggleSetting.default
+        })
+    }.toMap()
+
+    val userSettingMap = Setting.values().map { setting ->
+        setting to (UserSetting
+                .find { (UserSettingTable.userId eq uniqueId) and (UserSettingTable.settingId eq setting.id) }
+                .firstOrNull() ?: UserSetting.new {
+            user = this@UserEntity.user
+            settingId = setting.id
+            value = setting.default
         })
     }.toMap()
 

--- a/src/main/kotlin/click/seichi/gigantic/database/dao/user/UserSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/database/dao/user/UserSetting.kt
@@ -1,0 +1,16 @@
+package click.seichi.gigantic.database.dao.user
+
+import click.seichi.gigantic.database.table.user.UserSettingTable
+import org.jetbrains.exposed.dao.EntityClass
+import org.jetbrains.exposed.dao.EntityID
+import org.jetbrains.exposed.dao.IntEntity
+
+class UserSetting(id: EntityID<Int>) : IntEntity(id) {
+    companion object : EntityClass<Int, UserSetting>(UserSettingTable)
+
+    var user by User referencedOn UserSettingTable.userId
+
+    var settingId by UserSettingTable.settingId
+
+    var value by UserSettingTable.value
+}

--- a/src/main/kotlin/click/seichi/gigantic/database/dao/user/UserSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/database/dao/user/UserSetting.kt
@@ -5,6 +5,10 @@ import org.jetbrains.exposed.dao.EntityClass
 import org.jetbrains.exposed.dao.EntityID
 import org.jetbrains.exposed.dao.IntEntity
 
+/**
+ * @author 2288-256
+ */
+
 class UserSetting(id: EntityID<Int>) : IntEntity(id) {
     companion object : EntityClass<Int, UserSetting>(UserSettingTable)
 

--- a/src/main/kotlin/click/seichi/gigantic/database/table/user/UserSettingTable.kt
+++ b/src/main/kotlin/click/seichi/gigantic/database/table/user/UserSettingTable.kt
@@ -1,0 +1,14 @@
+package click.seichi.gigantic.database.table.user
+
+import org.jetbrains.exposed.dao.IntIdTable
+
+/**
+ * @author 2288-256
+ */
+object UserSettingTable : IntIdTable("users_setting") {
+    val userId = reference("unique_id", UserTable).primaryKey()
+
+    val settingId = integer("setting_id").primaryKey()
+
+    val value = integer("setting_value").default(0)
+}

--- a/src/main/kotlin/click/seichi/gigantic/item/items/menu/RelicGeneratorButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/menu/RelicGeneratorButtons.kt
@@ -6,12 +6,18 @@ import click.seichi.gigantic.event.events.RelicGenerateEvent
 import click.seichi.gigantic.extension.*
 import click.seichi.gigantic.item.Button
 import click.seichi.gigantic.menu.menus.RelicGeneratorMenu
+import click.seichi.gigantic.menu.menus.RelicGeneratorMenu.reopen
+import click.seichi.gigantic.menu.menus.RelicGeneratorMenu.close
 import click.seichi.gigantic.message.messages.MenuMessages
 import click.seichi.gigantic.message.messages.menu.RelicGeneratorMenuMessages
 import click.seichi.gigantic.message.messages.menu.RelicMenuMessages
+import click.seichi.gigantic.message.messages.menu.ToolSwitchMessages
 import click.seichi.gigantic.player.Defaults
+import click.seichi.gigantic.player.Setting
+import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.relic.Relic
 import click.seichi.gigantic.sound.sounds.MenuSounds
+import click.seichi.gigantic.sound.sounds.PlayerSounds
 import click.seichi.gigantic.util.Random
 import click.seichi.gigantic.will.Will
 import org.bukkit.Bukkit
@@ -20,10 +26,11 @@ import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.inventory.ItemStack
+import java.util.*
 import kotlin.random.asKotlinRandom
 
 /**
- * @author tar0ss
+ * author tar0ss
  */
 object RelicGeneratorButtons {
 
@@ -66,9 +73,11 @@ object RelicGeneratorButtons {
     }
 
     val GENERATE = object : Button {
+        val genMultList = listOf(1, 10, 50, 100)
         override fun toShownItemStack(player: Player): ItemStack? {
             val selected = player.getOrPut(Keys.SELECTED_WILL)
             val generated = player.getOrPut(Keys.GENERATED_RELIC)
+            val genMultiValueIndex = Setting.RELIC_GENERATION_VALUE.getValue(player)
             return itemStackOf(Material.END_PORTAL_FRAME) {
                 clearLore()
                 when {
@@ -76,7 +85,7 @@ object RelicGeneratorButtons {
                     selected == null ->
                         setDisplayName(RelicGeneratorMenuMessages.NULL_OF_ETHEL.asSafety(player.wrappedLocale))
                     // 選択したエーテルが不足している場合
-                    player.ethel(selected) < Defaults.RELIC_GENERATOR_REQUIRE_ETHEL ->
+                    player.ethel(selected) < Defaults.RELIC_GENERATOR_REQUIRE_ETHEL * genMultList[genMultiValueIndex] ->
                         setDisplayName(RelicGeneratorMenuMessages.LOST_OF_ETHEL.asSafety(player.wrappedLocale))
                     else -> {
                         setDisplayName(RelicGeneratorMenuMessages.GENERATE.asSafety(player.wrappedLocale))
@@ -84,7 +93,7 @@ object RelicGeneratorButtons {
                                 selected.chatColor +
                                 "${ChatColor.BOLD}" +
                                 selected.getName(player.wrappedLocale) +
-                                RelicGeneratorMenuMessages.USE_ETHEL.asSafety(player.wrappedLocale)
+                                RelicGeneratorMenuMessages.USE_ETHEL(genMultList[genMultiValueIndex]).asSafety(player.wrappedLocale)
                         )
                     }
                 }
@@ -98,27 +107,61 @@ object RelicGeneratorButtons {
                 }
             }
         }
-
+        
         override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
             val selected = player.getOrPut(Keys.SELECTED_WILL) ?: return true
-            if (player.ethel(selected) < Defaults.RELIC_GENERATOR_REQUIRE_ETHEL) return true
+            val genMultiValueIndex = Setting.RELIC_GENERATION_VALUE.getValue(player)
+            if (player.ethel(selected) < Defaults.RELIC_GENERATOR_REQUIRE_ETHEL * genMultList[genMultiValueIndex]) return true
             // 減算処理
-            player.transform(Keys.ETHEL_MAP[selected]!!) { it - Defaults.RELIC_GENERATOR_REQUIRE_ETHEL }
+            player.transform(Keys.ETHEL_MAP[selected]!!) { it - Defaults.RELIC_GENERATOR_REQUIRE_ETHEL * genMultList[genMultiValueIndex]}
 
-            // ランダムにレリックを選択
-            val relic = Relic.values().filter { selected.has(it) }.random(Random.generator.asKotlinRandom())
-            // レリックを付与
-            relic.dropTo(player)
-            // レリックを保存
-            player.offer(Keys.GENERATED_RELIC, relic)
+            var lastRelic: Relic? = null
+            val relicCountMap = mutableMapOf<Relic, Int>()
+            
+            repeat(genMultList[genMultiValueIndex]) {
+                lastRelic = relicGenerate(selected, player)
+                lastRelic?.let { relic ->
+                    relicCountMap[relic] = relicCountMap.getOrDefault(relic, 0) + 1
+                }
+            }
+
             // 音を再生
             MenuSounds.RELIC_GENERATE.play(player.location)
             // 更新(サイドバー更新も兼ねて)
             Achievement.update(player, isForced = true)
-            // 再度開く
-            RelicGeneratorMenu.reopen(player)
 
-            Bukkit.getPluginManager().callEvent(RelicGenerateEvent(player, relic, selected, Defaults.RELIC_GENERATOR_REQUIRE_ETHEL))
+            val playerLocale = player.wrappedLocale
+            if (genMultList[genMultiValueIndex] != 1) {
+                if (ToggleSetting.RELIC_GENERATION_RESULT.getToggle(player)) {
+                    player.sendMessage(
+                        RelicGeneratorMenuMessages.GENERATE_MESSAGE_SIMPLE(selected, genMultList[genMultiValueIndex])
+                            .asSafety(playerLocale)
+                    )
+                    player.sendMessage(RelicGeneratorMenuMessages.GENERATE_MESSAGE_MORE_START.asSafety(playerLocale))
+                    for ((relic, count) in relicCountMap) {
+                        player.sendMessage(
+                            RelicGeneratorMenuMessages.GENERATE_MESSAGE_DETAIL(relic, count).asSafety(playerLocale)
+                        )
+                    }
+                    player.sendMessage(RelicGeneratorMenuMessages.GENERATE_MESSAGE_MORE_END.asSafety(playerLocale))
+                } else {
+                    player.sendMessage(
+                        RelicGeneratorMenuMessages.GENERATE_MESSAGE_SIMPLE(selected, genMultList[genMultiValueIndex])
+                            .asSafety(playerLocale)
+                    )
+                }
+            }
+
+            lastRelic?.let {
+                //todo: 2個目の引数generatedが現在使われていないので最後のレリックを渡している。使用するなら適切なものに変えるべき。
+                Bukkit.getPluginManager().callEvent(RelicGenerateEvent(player, it, selected, Defaults.RELIC_GENERATOR_REQUIRE_ETHEL * genMultList[genMultiValueIndex]))
+            }
+
+            if (genMultiValueIndex == 0) {
+                RelicGeneratorMenu.reopen(player)
+            } else {
+                close(player)
+            }
 
             // 更新後にすぐに削除
             runTaskLater(1L) {
@@ -127,26 +170,43 @@ object RelicGeneratorButtons {
             }
             return true
         }
+
+        private fun relicGenerate(selected: Will, player: Player): Relic {
+            // ランダムにレリックを選択
+            val relic = Relic.values().filter { selected.has(it) }.random(Random.generator.asKotlinRandom())
+            // レリックを付与
+            relic.dropTo(player)
+            // レリックを保存
+            player.offer(Keys.GENERATED_RELIC, relic)
+            return relic
+        }
     }
 
     val GENERATED = object : Button {
         override fun toShownItemStack(player: Player): ItemStack? {
-            val generated = player.getOrPut(Keys.GENERATED_RELIC) ?: return null
-            val will = Will.findByRelic(generated) ?: return null
-            return generated.getIcon().apply {
-                setDisplayName(player, RelicMenuMessages.RELIC_TITLE(will.chatColor, generated, generated.getDroppedNum(player)))
-                setLore(*generated.getLore(player.wrappedLocale).map { "${ChatColor.GRAY}" + it }.toTypedArray())
-                addLore("${ChatColor.WHITE}" + MenuMessages.LINE)
-                val multiplier = generated.calcMultiplier(player)
-                addLore(RelicMenuMessages.BONUS_EXP(multiplier.toBigDecimal()).asSafety(player.wrappedLocale))
-                val bonusLore = generated.getBonusLore(player.wrappedLocale)
-                bonusLore.forEachIndexed { index, s ->
-                    if (index == 0) {
-                        addLore(RelicMenuMessages.CONDITIONS_FIRST_LINE(s).asSafety(player.wrappedLocale))
-                    } else {
-                        addLore(RelicMenuMessages.CONDITIONS(s).asSafety(player.wrappedLocale))
+            if (Setting.RELIC_GENERATION_VALUE.getValue(player) == 0) {
+                val generated = player.getOrPut(Keys.GENERATED_RELIC) ?: return null
+                val will = Will.findByRelic(generated) ?: return null
+                return generated.getIcon().apply {
+                    setDisplayName(
+                        player,
+                        RelicMenuMessages.RELIC_TITLE(will.chatColor, generated, generated.getDroppedNum(player))
+                    )
+                    setLore(*generated.getLore(player.wrappedLocale).map { "${ChatColor.GRAY}" + it }.toTypedArray())
+                    addLore("${ChatColor.WHITE}" + MenuMessages.LINE)
+                    val multiplier = generated.calcMultiplier(player)
+                    addLore(RelicMenuMessages.BONUS_EXP(multiplier.toBigDecimal()).asSafety(player.wrappedLocale))
+                    val bonusLore = generated.getBonusLore(player.wrappedLocale)
+                    bonusLore.forEachIndexed { index, s ->
+                        if (index == 0) {
+                            addLore(RelicMenuMessages.CONDITIONS_FIRST_LINE(s).asSafety(player.wrappedLocale))
+                        } else {
+                            addLore(RelicMenuMessages.CONDITIONS(s).asSafety(player.wrappedLocale))
+                        }
                     }
                 }
+            } else {
+                return null
             }
         }
 
@@ -154,5 +214,71 @@ object RelicGeneratorButtons {
             return true
         }
     }
+    val GENERATE_VALUE_SETTING = object : Button {
+        override fun toShownItemStack(player: Player): ItemStack? {
+            val itemStack = ItemStack(Material.CHEST)
+            val genMultList = listOf(1, 10, 50, 100)
+            itemStack.amount = genMultList[Setting.RELIC_GENERATION_VALUE.getValue(player)]
+            return itemStack.apply {
+                setDisplayName(
+                    "${ChatColor.WHITE}${ChatColor.BOLD}" +
+                            Setting.RELIC_GENERATION_VALUE.getName(player.wrappedLocale)
+                )
+                val lore = mutableListOf<String>()
+                lore.addAll(Setting.RELIC_GENERATION_VALUE.getDescription(player))
+                setLore(*lore.toTypedArray())
+                addLore(ToolSwitchMessages.CLICK_TO_TOGGLE.asSafety(player.wrappedLocale))
+            }
+        }
+        val coolTimeSet = mutableSetOf<UUID>()
 
+        override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
+            val uniqueId = player.uniqueId
+            if (coolTimeSet.contains(uniqueId)) return false
+            coolTimeSet.add(uniqueId)
+            runTaskLater(5L) {
+                coolTimeSet.remove(uniqueId)
+            }
+            Setting.RELIC_GENERATION_VALUE.rotateValue(player)
+            PlayerSounds.TOGGLE.playOnly(player)
+            reopen(player)
+            player.updateDisplay(applyMainHand = true, applyOffHand = true)
+            return true
+        }
+    }
+    val GENERATE_NOTIFICATION_SETTING = object : Button {
+        override fun toShownItemStack(player: Player): ItemStack? {
+            val itemStack = ItemStack(Material.OAK_SIGN)
+            return itemStack.apply {
+                setDisplayName(
+                    "${ChatColor.WHITE}${ChatColor.BOLD}" +
+                            ToggleSetting.RELIC_GENERATION_RESULT.getName(player.wrappedLocale) + ": " +
+                            if (ToggleSetting.RELIC_GENERATION_RESULT.getToggle(player)) {
+                                "${ChatColor.GREEN}${ChatColor.BOLD}ON"
+                            } else {
+                                "${ChatColor.RED}${ChatColor.BOLD}OFF"
+                            }
+                )
+                addLore(RelicGeneratorMenuMessages.GENERATE_NOTIFICATION_SETTING_LORE.asSafety(player.wrappedLocale))
+                addLore("")
+                addLore(ToolSwitchMessages.CLICK_TO_TOGGLE.asSafety(player.wrappedLocale))
+            }
+        }
+
+        val coolTimeSet = mutableSetOf<UUID>()
+
+        override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
+            val uniqueId = player.uniqueId
+            if (coolTimeSet.contains(uniqueId)) return false
+            coolTimeSet.add(uniqueId)
+            runTaskLater(5L) {
+                coolTimeSet.remove(uniqueId)
+            }
+            ToggleSetting.RELIC_GENERATION_RESULT.toggle(player)
+            PlayerSounds.TOGGLE.playOnly(player)
+            reopen(player)
+            player.updateDisplay(applyMainHand = true, applyOffHand = true)
+            return true
+        }
+    }
 }

--- a/src/main/kotlin/click/seichi/gigantic/item/items/menu/RelicGeneratorButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/menu/RelicGeneratorButtons.kt
@@ -158,7 +158,7 @@ object RelicGeneratorButtons {
             }
 
             if (genMultiValueIndex == 0) {
-                RelicGeneratorMenu.reopen(player)
+                reopen(player)
             } else {
                 close(player)
             }

--- a/src/main/kotlin/click/seichi/gigantic/menu/menus/RelicGeneratorMenu.kt
+++ b/src/main/kotlin/click/seichi/gigantic/menu/menus/RelicGeneratorMenu.kt
@@ -53,6 +53,9 @@ object RelicGeneratorMenu : Menu() {
 
         registerButton(31, RelicGeneratorButtons.GENERATED)
         registerButton(49, RelicGeneratorButtons.GENERATE)
+
+        registerButton(48, RelicGeneratorButtons.GENERATE_NOTIFICATION_SETTING)
+        registerButton(50, RelicGeneratorButtons.GENERATE_VALUE_SETTING)
     }
 
 }

--- a/src/main/kotlin/click/seichi/gigantic/menu/menus/setting/CategorySettingMenu.kt
+++ b/src/main/kotlin/click/seichi/gigantic/menu/menus/setting/CategorySettingMenu.kt
@@ -107,6 +107,7 @@ class CategorySettingMenu(private val category: ToggleSetting.Category) : Menu()
                         runTaskLater(5L) {
                             coolTimeSet.remove(uniqueId)
                         }
+                        setting.rotateValue(player)
                         PlayerSounds.TOGGLE.playOnly(player)
                         reopen(player)
                         player.updateDisplay(applyMainHand = true, applyOffHand = true)

--- a/src/main/kotlin/click/seichi/gigantic/menu/menus/setting/CategorySettingMenu.kt
+++ b/src/main/kotlin/click/seichi/gigantic/menu/menus/setting/CategorySettingMenu.kt
@@ -7,6 +7,7 @@ import click.seichi.gigantic.menu.Menu
 import click.seichi.gigantic.menu.menus.SettingMenu
 import click.seichi.gigantic.message.messages.menu.SettingMenuMessages
 import click.seichi.gigantic.message.messages.menu.ToolSwitchMessages
+import click.seichi.gigantic.player.Setting
 import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.sound.sounds.PlayerSounds
 import org.bukkit.ChatColor
@@ -29,10 +30,11 @@ class CategorySettingMenu(private val category: ToggleSetting.Category) : Menu()
     }
 
     init {
+        var slotNum = -1
         ToggleSetting.values()
             .filter { it.category == category }
             .forEachIndexed { index, setting ->
-                var slotNum = index
+                slotNum++
                 // 見栄えが悪いので18スロット以降にはボタンを置かない
                 if (index >= 18) return@forEachIndexed
 
@@ -68,6 +70,43 @@ class CategorySettingMenu(private val category: ToggleSetting.Category) : Menu()
                             coolTimeSet.remove(uniqueId)
                         }
                         setting.toggle(player)
+                        PlayerSounds.TOGGLE.playOnly(player)
+                        reopen(player)
+                        player.updateDisplay(applyMainHand = true, applyOffHand = true)
+                        return true
+                    }
+                })
+            }
+        Setting.values()
+            .filter { it.category == category }
+            .forEachIndexed { index, setting ->
+                slotNum++
+                if (index >= 18) return@forEachIndexed
+                registerButton(slotNum, object : Button {
+
+                    override fun toShownItemStack(player: Player): ItemStack? {
+                        val itemStack = ItemStack(Material.OAK_SIGN)
+                        return itemStack.apply {
+                            setDisplayName(
+                                "${ChatColor.WHITE}${ChatColor.BOLD}" +
+                                        setting.getName(player.wrappedLocale)
+                            )
+                            val lore = mutableListOf<String>()
+                            lore.addAll(setting.getDescription(player))
+                            setLore(*lore.toTypedArray())
+                            addLore(ToolSwitchMessages.CLICK_TO_TOGGLE.asSafety(player.wrappedLocale))
+                        }
+                    }
+
+                    val coolTimeSet = mutableSetOf<UUID>()
+
+                    override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
+                        val uniqueId = player.uniqueId
+                        if (coolTimeSet.contains(uniqueId)) return false
+                        coolTimeSet.add(uniqueId)
+                        runTaskLater(5L) {
+                            coolTimeSet.remove(uniqueId)
+                        }
                         PlayerSounds.TOGGLE.playOnly(player)
                         reopen(player)
                         player.updateDisplay(applyMainHand = true, applyOffHand = true)

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/menu/RelicGeneratorMenuMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/menu/RelicGeneratorMenuMessages.kt
@@ -2,6 +2,8 @@ package click.seichi.gigantic.message.messages.menu
 
 import click.seichi.gigantic.message.LocalizedText
 import click.seichi.gigantic.player.Defaults
+import click.seichi.gigantic.relic.Relic
+import click.seichi.gigantic.will.Will
 import org.bukkit.ChatColor
 import java.util.*
 
@@ -33,9 +35,11 @@ object RelicGeneratorMenuMessages {
                     "必要なエーテルが足りません"
     )
 
-    val USE_ETHEL = LocalizedText(
-            Locale.JAPANESE to "のエーテルを${Defaults.RELIC_GENERATOR_REQUIRE_ETHEL}消費します"
-    )
+    val USE_ETHEL = { multiValue: Int ->
+        LocalizedText(
+            Locale.JAPANESE to "のエーテルを${Defaults.RELIC_GENERATOR_REQUIRE_ETHEL * multiValue}消費します"
+        )
+    }
 
     val GENERATE = LocalizedText(
             Locale.JAPANESE to "${ChatColor.RESET}" +
@@ -47,4 +51,27 @@ object RelicGeneratorMenuMessages {
             Locale.JAPANESE to "が生成されました"
     )
 
+    val GENERATE_NOTIFICATION_SETTING_LORE = LocalizedText(
+            Locale.JAPANESE to "${ChatColor.RED}チャットに結果が送信されるのは複数個一度に作成した場合のみです。"
+    )
+    val GENERATE_MESSAGE_SIMPLE = { selectedWill: Will, amount: Int ->
+        LocalizedText(
+            Locale.JAPANESE.let {
+                it to "${ChatColor.YELLOW}[レリック] ${selectedWill.chatColor}${ChatColor.BOLD}${selectedWill.getName(it)}${ChatColor.RESET}${ChatColor.GREEN}のレリックを${amount}個生成しました。"
+            }
+        )
+    }
+    val GENERATE_MESSAGE_MORE_START = LocalizedText(
+        Locale.JAPANESE to "${ChatColor.YELLOW}[レリック] ${ChatColor.WHITE}======== 生成したレリック ========"
+    )
+    val GENERATE_MESSAGE_MORE_END = LocalizedText(
+        Locale.JAPANESE to "${ChatColor.YELLOW}[レリック] ${ChatColor.WHITE}============================="
+    )
+    val GENERATE_MESSAGE_DETAIL = { relic: Relic, amount: Int ->
+        LocalizedText(
+            Locale.JAPANESE.let {
+                it to "${ChatColor.YELLOW}[レリック] ${Will.findByRelic(relic)?.chatColor}${relic.getName(it)} ${ChatColor.GRAY}x$amount"
+            }
+        )
+    }
 }

--- a/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
@@ -1,0 +1,22 @@
+package click.seichi.gigantic.player
+
+import click.seichi.gigantic.cache.key.Keys
+import click.seichi.gigantic.extension.getOrPut
+import click.seichi.gigantic.extension.transform
+import click.seichi.gigantic.message.LocalizedText
+import org.bukkit.entity.Player
+import java.util.*
+
+enum class Setting(
+    val id: Int,
+    private val localizedName: LocalizedText,
+    val default: Int,
+    val range: Int,
+    val category: ToggleSetting.Category
+) {
+    fun getName(locale: Locale) = localizedName.asSafety(locale)
+
+    fun getToggle(player: Player) = player.getOrPut(Keys.SETTING_MAP.getValue(this))
+
+    fun setValue(player: Player) = player.transform(Keys.SETTING_MAP.getValue(this)) { it }
+}

--- a/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
@@ -3,7 +3,9 @@ package click.seichi.gigantic.player
 import click.seichi.gigantic.cache.key.Keys
 import click.seichi.gigantic.extension.getOrPut
 import click.seichi.gigantic.extension.transform
+import click.seichi.gigantic.extension.wrappedLocale
 import click.seichi.gigantic.message.LocalizedText
+import org.bukkit.ChatColor
 import org.bukkit.entity.Player
 import java.util.*
 
@@ -12,11 +14,20 @@ enum class Setting(
     private val localizedName: LocalizedText,
     val default: Int,
     val range: Int,
-    val category: ToggleSetting.Category
+    val category: ToggleSetting.Category,
+    private val descriptions: Map<Int, LocalizedText> = emptyMap()
 ) {
     fun getName(locale: Locale) = localizedName.asSafety(locale)
 
-    fun getToggle(player: Player) = player.getOrPut(Keys.SETTING_MAP.getValue(this))
+    fun getDescription(player: Player): List<String> {
+        val value = getValue(player)
+        return (0..range).map { i ->
+            val text = descriptions[i]?.asSafety(player.wrappedLocale) ?: ""
+            if (i == value) "${ChatColor.GREEN}▶ $text" else "${ChatColor.GRAY}   $text"
+        }
+    }
 
-    fun setValue(player: Player) = player.transform(Keys.SETTING_MAP.getValue(this)) { it }
+    fun getValue(player: Player) = player.getOrPut(Keys.SETTING_MAP.getValue(this))
+
+    fun rotateValue(player: Player) = player.transform(Keys.SETTING_MAP.getValue(this)) { (it + 1) % range }
 }

--- a/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
@@ -9,6 +9,10 @@ import org.bukkit.ChatColor
 import org.bukkit.entity.Player
 import java.util.*
 
+/**
+ * @author 2288-256
+ */
+
 enum class Setting(
     val id: Int,
     private val localizedName: LocalizedText,

--- a/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
@@ -51,6 +51,25 @@ enum class Setting(
                 Locale.JAPANESE to "両方非表示"
             )
         )
+    ),
+    RELIC_GENERATION_VALUE(
+        2, LocalizedText(
+            Locale.JAPANESE to "レリックを一度に生成する量"
+        ),0,4,ToggleSetting.Category.FUNCTION,
+        mapOf(
+            0 to LocalizedText(
+                Locale.JAPANESE to "1個"
+            ),
+            1 to LocalizedText(
+                Locale.JAPANESE to "10個"
+            ),
+            2 to LocalizedText(
+                Locale.JAPANESE to "50個"
+            ),
+            3 to LocalizedText(
+                Locale.JAPANESE to "100個"
+            )
+        )
     );
     fun getName(locale: Locale) = localizedName.asSafety(locale)
 

--- a/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
@@ -18,7 +18,7 @@ enum class Setting(
     private val descriptions: Map<Int, LocalizedText> = emptyMap()
 ) {
     SEE_WILL_BOSSBAR(
-        7, LocalizedText(
+        0, LocalizedText(
             Locale.JAPANESE to "意志の交感中表示"
         ), 0, 3, ToggleSetting.Category.FUNCTION,
         mapOf(

--- a/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
@@ -32,6 +32,25 @@ enum class Setting(
                 Locale.JAPANESE to "すべて表示"
             )
         )
+    ),
+    MANA_HP_DISPLAY(
+        1, LocalizedText(
+            Locale.JAPANESE to "マナ回復・HP回復の表示"
+        ), 0,4, ToggleSetting.Category.DISPLAY,
+        mapOf(
+            0 to LocalizedText(
+                Locale.JAPANESE to "表示"
+            ),
+            1 to LocalizedText(
+                Locale.JAPANESE to "マナ回復のみ非表示"
+            ),
+            2 to LocalizedText(
+                Locale.JAPANESE to "HP回復のみ非表示"
+            ),
+            3 to LocalizedText(
+                Locale.JAPANESE to "両方非表示"
+            )
+        )
     );
     fun getName(locale: Locale) = localizedName.asSafety(locale)
 

--- a/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/Setting.kt
@@ -17,6 +17,22 @@ enum class Setting(
     val category: ToggleSetting.Category,
     private val descriptions: Map<Int, LocalizedText> = emptyMap()
 ) {
+    SEE_WILL_BOSSBAR(
+        7, LocalizedText(
+            Locale.JAPANESE to "意志の交感中表示"
+        ), 0, 3, ToggleSetting.Category.FUNCTION,
+        mapOf(
+            0 to LocalizedText(
+                Locale.JAPANESE to "表示しない"
+            ),
+            1 to LocalizedText(
+                Locale.JAPANESE to "神友以外表示"
+            ),
+            2 to LocalizedText(
+                Locale.JAPANESE to "すべて表示"
+            )
+        )
+    );
     fun getName(locale: Locale) = localizedName.asSafety(locale)
 
     fun getDescription(player: Player): List<String> {

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -51,23 +51,18 @@ enum class ToggleSetting(
             Locale.JAPANESE to "コンボ表示位置の修正"
         ), true, Category.FUNCTION
     ),
-    SEE_WILL_BOSSBAR(
-        7, LocalizedText(
-            Locale.JAPANESE to "意志の交感中表示"
-        ), true, Category.FUNCTION
-    ),
     UPDATE_RANKING(
-        8, LocalizedText(
+        7, LocalizedText(
             Locale.JAPANESE to "ランキングの更新通知"
         ), false, Category.NOTIFICATION
     ),
     MANA_HP_DISPLAY(
-        9, LocalizedText(
+        8, LocalizedText(
             Locale.JAPANESE to "マナ回復・HP回復の表示"
         ), true, Category.DISPLAY
     ),
     SCOREBOARD_MANA(
-        10, LocalizedText(
+        9, LocalizedText(
             Locale.JAPANESE to "スコアボードにマナの情報を表示"
         ), false, Category.DISPLAY
     ),

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -76,6 +76,11 @@ enum class ToggleSetting(
             Locale.JAPANESE to "コンボランキングの通知"
         ), true, Category.NOTIFICATION
     ),
+    RELIC_GENERATION_RESULT(
+        12, LocalizedText(
+            Locale.JAPANESE to "レリック生成結果をチャットで送信"
+        ), true, Category.NOTIFICATION
+    )
     ;
 
     fun getName(locale: Locale) = localizedName.asSafety(locale)

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -52,34 +52,34 @@ enum class ToggleSetting(
         ), true, Category.FUNCTION
     ),
     UPDATE_RANKING(
-        7, LocalizedText(
+        8, LocalizedText(
             Locale.JAPANESE to "ランキングの更新通知"
         ), false, Category.NOTIFICATION
     ),
     SCOREBOARD_MANA(
-        8, LocalizedText(
+        10, LocalizedText(
             Locale.JAPANESE to "スコアボードにマナの情報を表示"
         ), false, Category.DISPLAY
     ),
-    SCOREBOARD_TOTAL_EXP(
-        9, LocalizedText(
-            Locale.JAPANESE to "スコアボードに総経験値量の情報を表示"
-        ), false, Category.DISPLAY
-    ),
     TIPS_NOTIFICATION(
-        10, LocalizedText(
+        11, LocalizedText(
             Locale.JAPANESE to "TIPSの通知"
         ), true, Category.NOTIFICATION
     ),
     COMBO_RANKING_NOTIFICATION(
-        11, LocalizedText(
+        12, LocalizedText(
             Locale.JAPANESE to "コンボランキングの通知"
         ), true, Category.NOTIFICATION
     ),
     RELIC_GENERATION_RESULT(
-        12, LocalizedText(
+        14, LocalizedText(
             Locale.JAPANESE to "レリック生成結果をチャットで送信"
         ), true, Category.NOTIFICATION
+    ),
+    SCOREBOARD_TOTAL_EXP(
+        13, LocalizedText(
+            Locale.JAPANESE to "スコアボードに総経験値量の情報を表示"
+        ), false, Category.DISPLAY
     )
     ;
 

--- a/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/ToggleSetting.kt
@@ -56,28 +56,23 @@ enum class ToggleSetting(
             Locale.JAPANESE to "ランキングの更新通知"
         ), false, Category.NOTIFICATION
     ),
-    MANA_HP_DISPLAY(
-        8, LocalizedText(
-            Locale.JAPANESE to "マナ回復・HP回復の表示"
-        ), true, Category.DISPLAY
-    ),
     SCOREBOARD_MANA(
-        9, LocalizedText(
+        8, LocalizedText(
             Locale.JAPANESE to "スコアボードにマナの情報を表示"
         ), false, Category.DISPLAY
     ),
     SCOREBOARD_TOTAL_EXP(
-        10, LocalizedText(
+        9, LocalizedText(
             Locale.JAPANESE to "スコアボードに総経験値量の情報を表示"
         ), false, Category.DISPLAY
     ),
     TIPS_NOTIFICATION(
-        11, LocalizedText(
+        10, LocalizedText(
             Locale.JAPANESE to "TIPSの通知"
         ), true, Category.NOTIFICATION
     ),
     COMBO_RANKING_NOTIFICATION(
-        12, LocalizedText(
+        11, LocalizedText(
             Locale.JAPANESE to "コンボランキングの通知"
         ), true, Category.NOTIFICATION
     ),

--- a/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
@@ -11,6 +11,7 @@ import click.seichi.gigantic.message.messages.PopUpMessages
 import click.seichi.gigantic.player.Defaults
 import click.seichi.gigantic.player.Invokable
 import click.seichi.gigantic.player.Setting
+import click.seichi.gigantic.player.ToggleSetting
 import click.seichi.gigantic.popup.PopUp
 import click.seichi.gigantic.popup.SimpleAnimation
 import click.seichi.gigantic.sound.sounds.PlayerSounds

--- a/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
@@ -10,7 +10,7 @@ import click.seichi.gigantic.message.messages.PlayerMessages
 import click.seichi.gigantic.message.messages.PopUpMessages
 import click.seichi.gigantic.player.Defaults
 import click.seichi.gigantic.player.Invokable
-import click.seichi.gigantic.player.ToggleSetting
+import click.seichi.gigantic.player.Setting
 import click.seichi.gigantic.popup.PopUp
 import click.seichi.gigantic.popup.SimpleAnimation
 import click.seichi.gigantic.sound.sounds.PlayerSounds
@@ -135,7 +135,7 @@ object Skills {
                 val diff = nextHealth - p.health
                 p.health = nextHealth
 
-                if (ToggleSetting.MANA_HP_DISPLAY.getToggle(p)) {
+                if (Setting.MANA_HP_DISPLAY.getValue(p) in 0..1) {
                     SkillAnimations.HEAL.absorb(p, block.centralLocation)
                     PopUp(SimpleAnimation, block.centralLocation.add(0.0, 0.2, 0.0), PopUpMessages.HEAL(diff))
                         .pop()

--- a/src/main/kotlin/click/seichi/gigantic/player/spell/Spells.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/spell/Spells.kt
@@ -12,7 +12,7 @@ import click.seichi.gigantic.message.messages.PlayerMessages
 import click.seichi.gigantic.message.messages.PopUpMessages
 import click.seichi.gigantic.player.Defaults
 import click.seichi.gigantic.player.Invokable
-import click.seichi.gigantic.player.ToggleSetting
+import click.seichi.gigantic.player.Setting
 import click.seichi.gigantic.popup.PopUp
 import click.seichi.gigantic.popup.SimpleAnimation
 import click.seichi.gigantic.sound.sounds.SpellSounds
@@ -41,7 +41,7 @@ object Spells {
                     wrappedAmount = it.increase(it.max.divide(100.toBigDecimal(), 10, RoundingMode.HALF_UP).times(Config.SPELL_STELLA_CLAIR_RATIO.toBigDecimal()))
                 }
 
-                if (ToggleSetting.MANA_HP_DISPLAY.getToggle(p)) {
+                if (Setting.MANA_HP_DISPLAY.getValue(p) == 0 || Setting.MANA_HP_DISPLAY.getValue(p) == 2) {
                     SpellAnimations.STELLA_CLAIR.absorb(p, block.centralLocation)
                     PopUp(
                         SimpleAnimation,

--- a/src/main/kotlin/click/seichi/gigantic/spirit/spirits/WillSpirit.kt
+++ b/src/main/kotlin/click/seichi/gigantic/spirit/spirits/WillSpirit.kt
@@ -7,7 +7,7 @@ import click.seichi.gigantic.extension.isCrust
 import click.seichi.gigantic.extension.relationship
 import click.seichi.gigantic.message.messages.WillMessages
 import click.seichi.gigantic.player.Defaults
-import click.seichi.gigantic.player.ToggleSetting
+import click.seichi.gigantic.player.Setting
 import click.seichi.gigantic.sound.sounds.WillSpiritSounds
 import click.seichi.gigantic.spirit.Sensor
 import click.seichi.gigantic.spirit.Spirit
@@ -66,8 +66,15 @@ class WillSpirit(
                 }
             // 意志との交感進捗
             // 関係がPARTNER(神友)の場合は範囲無制限なので表示させない
-            if (ToggleSetting.SEE_WILL_BOSSBAR.getToggle(player) && player.relationship(this.will) != WillRelationship.PARTNER) {
-                bossBarUpdate(count, this)
+            when (Setting.SEE_WILL_BOSSBAR.getValue(player)) {
+                1 -> {
+                    if (player.relationship(this.will) != WillRelationship.PARTNER) {
+                        bossBarUpdate(count, this)
+                    }
+                }
+                2 -> {
+                    bossBarUpdate(count, this)
+                }
             }
             },
             { player ->


### PR DESCRIPTION
このプルリクエストは、主にユーザー設定機能の追加とレリック生成機能の強化に焦点を当てています。主な変更内容は、新しいユーザー設定テーブルの追加、設定可能な乗数をサポートするためのレリック生成ロジックの更新、そして設定用のユーザーインターフェースの強化です。

### ユーザー設定の追加:
* ユーザー固有の設定を保存するための新しい `UserSettingTable` を追加しました (`src/main/kotlin/click/seichi/gigantic/database/table/user/UserSettingTable.kt`)。
* データベース内のユーザー設定を表現する新しい `UserSetting` クラスを作成しました (`src/main/kotlin/click/seichi/gigantic/database/dao/user/UserSetting.kt`)。
* `UserSettingTable` をメインプラグインクラスに統合しました (`src/main/kotlin/click/seichi/gigantic/Gigantic.kt`)。

### レリック生成機能の強化:
* レリック生成ロジックを更新し、設定可能な乗数を使用するようにしました。これにより、ユーザーが一度に複数の遺物を生成できるようになります (`src/main/kotlin/click/seichi/gigantic/item/items/menu/RelicGeneratorButtons.kt`)。
* レリック生成メニューに、レリック生成乗数の設定と通知設定の切り替えボタンを追加しました (`src/main/kotlin/click/seichi/gigantic/menu/menus/RelicGeneratorMenu.kt`)。

### ユーザーインターフェースの強化:
* `CategorySettingMenu` を更新し、ユーザーが直接メニューから設定を構成できるようにユーザー設定用のボタンを追加しました (`src/main/kotlin/click/seichi/gigantic/menu/menus/setting/CategorySettingMenu.kt`)。
* レリック生成機能と設定をサポートするために、新しいメッセージを `RelicGeneratorMenuMessages` クラスに追加しました (`src/main/kotlin/click/seichi/gigantic/message/messages/menu/RelicGeneratorMenuMessages.kt`)。


close #36