### PR TITLE
feat: バケツアイテムを追加し、無限水吸収エンチャントを実装 (#19)

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/belt/Belt.kt
+++ b/src/main/kotlin/click/seichi/gigantic/belt/Belt.kt
@@ -40,6 +40,7 @@ enum class Belt(
             2 to HandItems.MINE_BURST,
             3 to HandItems.SKY_WALK,
             Defaults.TOTEM_SLOT to HandItems.TOTEM,
+            7 to HandItems.BUCKET,
             8 to HandItems.JUMP
     ),
     ;

--- a/src/main/kotlin/click/seichi/gigantic/enchantment/ToolEnchantment.kt
+++ b/src/main/kotlin/click/seichi/gigantic/enchantment/ToolEnchantment.kt
@@ -85,6 +85,17 @@ enum class ToolEnchantment(
             return 1
         }
     },
+    INF_DRAIN(
+        LocalizedText(Locale.JAPANESE to "無限水吸収")
+    ) {
+        override fun isMatch(player: Player, itemStack: ItemStack): Boolean {
+            return true
+        }
+
+        override fun calcLevel(player: Player, itemStack: ItemStack): Int {
+            return 1
+        }
+    },
     ;
 
     protected abstract fun isMatch(player: Player, itemStack: ItemStack): Boolean

--- a/src/main/kotlin/click/seichi/gigantic/item/items/HandItems.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/HandItems.kt
@@ -83,6 +83,27 @@ object HandItems {
         }
     }
 
+    val BUCKET = object : HandItem {
+        override fun toShownItemStack(player: Player): ItemStack? {
+            return itemStackOf(Material.BUCKET) {
+                setDisplayName("${ChatColor.AQUA}${ChatColor.ITALIC}" +
+                        HandItemMessages.BUCKET.asSafety(player.wrappedLocale))
+                addLore(HandItemMessages.BUCKET_LORE.asSafety(player.wrappedLocale))
+                setEnchanted(true)
+                modifyItemMeta(this, player)
+            }
+        }
+
+        override fun tryInteract(player: Player, event: PlayerInteractEvent): Boolean {
+            Bukkit.getScheduler().scheduleSyncDelayedTask(Gigantic.PLUGIN, {
+                if (player.inventory.getItem(player.inventory.heldItemSlot)?.type != Material.BUCKET) {
+                    player.inventory.setItem(player.inventory.heldItemSlot, toShownItemStack(player))
+                }
+            }, 1L)
+            return true
+        }
+    }
+
     private fun modifyItemMeta(itemStack: ItemStack, player: Player) {
         itemStack.run {
             itemMeta = itemMeta?.apply {
@@ -91,7 +112,15 @@ object HandItems {
                 addItemFlags(ItemFlag.HIDE_ENCHANTS)
                 addItemFlags(ItemFlag.HIDE_UNBREAKABLE)
             }
-            ToolEnchantment.values().forEach { it.addIfMatch(player, itemStack) }
+            if (itemStack.type == Material.BUCKET) {
+                ToolEnchantment.INF_DRAIN.addIfMatch(player, itemStack)
+            } else {
+                ToolEnchantment.values().forEach {
+                    if (it != ToolEnchantment.INF_DRAIN) {
+                        it.addIfMatch(player, itemStack)
+                    }
+                }
+            }
         }
     }
 
@@ -296,6 +325,5 @@ object HandItems {
 
         }
     }
-
 
 }

--- a/src/main/kotlin/click/seichi/gigantic/listener/PlayerListener.kt
+++ b/src/main/kotlin/click/seichi/gigantic/listener/PlayerListener.kt
@@ -278,6 +278,17 @@ class PlayerListener : Listener {
         event.isCancelled = true
     }
 
+    // スポーン付近を破壊した場合問答無用でキャンセル
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun cancelBucketSpawnArea(event: PlayerBucketFillEvent) {
+        val player = event.player
+        val block = event.block
+        if (player.gameMode != GameMode.SURVIVAL) return
+        if (!block.isSpawnArea) return
+        PlayerMessages.SPAWN_PROTECT.sendTo(player)
+        event.isCancelled = true
+    }
+
     // ツール以外で破壊したときキャンセル
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     fun cancelNotToolBreaking(event: BlockBreakEvent) {

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/HandItemMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/HandItemMessages.kt
@@ -219,5 +219,13 @@ object HandItemMessages {
                     )
             )
 
+    val BUCKET = LocalizedText(
+        Locale.JAPANESE to "不思議なバケツ"
+    )
+
+    val BUCKET_LORE = LocalizedText(
+        Locale.JAPANESE to "${ChatColor.WHITE}" +
+            "どんなに使ってもすぐに液体が消える"
+    )
 
 }


### PR DESCRIPTION
このプルリクエストは、新機能をいくつか導入し、さらに`PlayerListener`クラスで新しいイベントハンドリングを追加しています。最も重要な変更点は、新しい`BUCKET`アイテム、新しい`INF_DRAIN`エンチャントメント、そして保護されたスポーンエリアでのバケツ使用に関するイベント処理の追加です。

新しいアイテムとエンチャントメント:

* `src/main/kotlin/click/seichi/gigantic/item/items/HandItems.kt`: 新しい`BUCKET`アイテムが追加され、インタラクション動作が設定されました。
* `src/main/kotlin/click/seichi/gigantic/enchantment/ToolEnchantment.kt`: 新しい`INF_DRAIN`エンチャントメントが導入されました。

イベント処理:

* `src/main/kotlin/click/seichi/gigantic/listener/PlayerListener.kt`: 新しいイベントハンドラ`cancelBucketSpawnArea`が追加され、保護されたスポーンエリアでのバケツ使用を防止します。

サポートする変更:

* `src/main/kotlin/click/seichi/gigantic/belt/Belt.kt`: 新しい`BUCKET`アイテムを含むように`Belt`列挙型が更新されました。
* `src/main/kotlin/click/seichi/gigantic/message/messages/HandItemMessages.kt`: `BUCKET`アイテムとそのロアのためのローカライズメッセージが追加されました。

close #19