### PR TITLE
enhance: レリック一覧で意志選択時にエンチャントを設定し、選択されていることをわかりやすくする

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/item/items/menu/RelicButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/menu/RelicButtons.kt
@@ -46,6 +46,9 @@ object RelicButtons {
                                         it.asSafety(player.wrappedLocale)
                                     }.toTypedArray()
                     )
+                    if (player.getOrPut(Keys.MENU_RELIC_CATEGORY) == category) {
+                        setEnchanted(true)
+                    }
                 }
             }
 
@@ -117,6 +120,9 @@ object RelicButtons {
                                     it.asSafety(player.wrappedLocale)
                                 }.toTypedArray()
                 )
+                if (player.getOrPut(Keys.MENU_RELIC_CATEGORY) == category) {
+                    setEnchanted(true)
+                }
             }
         }
 
@@ -141,6 +147,9 @@ object RelicButtons {
         override fun toShownItemStack(player: Player): ItemStack? {
             return itemStackOf(Material.GRASS_BLOCK) {
                 setDisplayName(player, RelicMenuMessages.ALL_RELIC_MENU_TITLE)
+                if (player.getOrPut(Keys.MENU_RELIC_CATEGORY) == category) {
+                    setEnchanted(true)
+                }
             }
         }
 
@@ -176,6 +185,9 @@ object RelicButtons {
                                     it.asSafety(player.wrappedLocale)
                                 }.toTypedArray()
                 )
+                if (player.getOrPut(Keys.MENU_RELIC_CATEGORY) == category) {
+                    setEnchanted(true)
+                }
             }
         }
 


### PR DESCRIPTION
close #44

## このPRの変更点と理由
- RelicButtonsで、各意志の選択にエンチャント設定を有効にした
- ボーナス発生中レリックの選択時、全てのレリック一覧の選択時にエンチャント設定を有効にした

## 補足
- 全てのレリック一覧の選択時
![image](https://github.com/user-attachments/assets/f90346d8-00b7-42db-82ca-c12510bff512)

- 土レリックの一覧の選択時 
![image](https://github.com/user-attachments/assets/ff296567-9959-4423-8306-c4df7cd827db)
