### PR TITLE
feat: wikiのリンクを追加 (#65)

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/item/items/BagButtons.kt
+++ b/src/main/kotlin/click/seichi/gigantic/item/items/BagButtons.kt
@@ -634,7 +634,8 @@ object BagButtons {
 
         override fun tryClick(player: Player, event: InventoryClickEvent): Boolean {
             player.sendMessage(BagMessages.WIKI_MESSAGE_OFFICIAL.asSafety(player.wrappedLocale))
-            player.sendMessage(BagMessages.WIKI_MESSAGE_UNOFFICIAL.asSafety(player.wrappedLocale))
+            player.sendMessage(BagMessages.WIKI_MESSAGE_OLD_OFFICIAL.asSafety(player.wrappedLocale))
+            player.sendMessage(BagMessages.WIKI_MESSAGE_OLD_UNOFFICIAL.asSafety(player.wrappedLocale))
             player.closeInventory()
             return true
         }

--- a/src/main/kotlin/click/seichi/gigantic/message/Tips.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/Tips.kt
@@ -47,9 +47,12 @@ enum class Tips(
             LocalizedText(
                 Locale.JAPANESE to Defaults.TIPS_PREFIX +
                         "${ChatColor.WHITE}" +
-                        "元祖整地鯖(春)非公式Wiki→" +
+                        "非公式整地鯖(春) 公認Wiki→" +
                         "${ChatColor.AQUA}" +
-                        "https://springseichi.sokuhou.wiki/"
+                        "https://wiki.seichi-haru.pgw.jp/"+
+                        LinedChatMessage.NEW_LINE_SYMBOL +
+                        Defaults.TIPS_PREFIX +
+                        "公認Wikiでは編集者を募集しています！"
             ), 2L)),
     HOME(LinedChatMessage(ChatMessageProtocol.CHAT,
         LocalizedText(

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/BagMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/BagMessages.kt
@@ -255,11 +255,15 @@ object BagMessages {
     )
 
     val WIKI_MESSAGE_OFFICIAL = LocalizedText(
-            Locale.JAPANESE to "元祖整地鯖(春)公式Wiki: " + "${ChatColor.RED}${ChatColor.UNDERLINE}" + "https://www.seichi.network/spring"
+        Locale.JAPANESE to "非公式整地鯖(春) 公認Wiki: " + "${ChatColor.RED}${ChatColor.UNDERLINE}" + "https://wiki.seichi-haru.pgw.jp/"
     )
 
-    val WIKI_MESSAGE_UNOFFICIAL = LocalizedText(
-            Locale.JAPANESE to "元祖整地鯖(春)非公式Wiki: " + "${ChatColor.RED}${ChatColor.UNDERLINE}" + "https://springseichi.sokuhou.wiki"
+    val WIKI_MESSAGE_OLD_OFFICIAL = LocalizedText(
+            Locale.JAPANESE to "${ChatColor.GRAY}元祖整地鯖(春)公式Wiki: " + "${ChatColor.GRAY}${ChatColor.UNDERLINE}" + "https://www.seichi.network/spring"
+    )
+
+    val WIKI_MESSAGE_OLD_UNOFFICIAL = LocalizedText(
+            Locale.JAPANESE to "${ChatColor.GRAY}元祖整地鯖(春)非公式Wiki: " + "${ChatColor.GRAY}${ChatColor.UNDERLINE}" + "https://springseichi.sokuhou.wiki"
     )
 
     val RANKING = LocalizedText(

--- a/src/main/kotlin/click/seichi/gigantic/message/messages/LoginMessages.kt
+++ b/src/main/kotlin/click/seichi/gigantic/message/messages/LoginMessages.kt
@@ -36,11 +36,6 @@ object LoginMessages {
                     "https://s.seichi-haru.pgw.jp/github" +
                     LinedChatMessage.NEW_LINE_SYMBOL +
                     "${ChatColor.WHITE}" +
-                    "実装予定の機能・発生中の不具合: " +
-                    "${ChatColor.YELLOW}" +
-                    "https://s.seichi-haru.pgw.jp/issues" +
-                    LinedChatMessage.NEW_LINE_SYMBOL +
-                    "${ChatColor.WHITE}" +
                     "リリースノート: " +
                     "${ChatColor.YELLOW}" +
                     "https://s.seichi-haru.pgw.jp/releases" +
@@ -59,6 +54,11 @@ object LoginMessages {
                     "WebMap: " +
                     "${ChatColor.YELLOW}" +
                     "https://map.seichi-haru.pgw.jp" +
+                    LinedChatMessage.NEW_LINE_SYMBOL +
+                    "${ChatColor.WHITE}" +
+                    "公認Wiki: " +
+                    "${ChatColor.YELLOW}" +
+                    "https://wiki.seichi-haru.pgw.jp" +
                     LinedChatMessage.NEW_LINE_SYMBOL +
                     LinedChatMessage.NEW_LINE_SYMBOL +
                     "${ChatColor.WHITE}" +


### PR DESCRIPTION
# このPRでの変更点
- wikiのリンクを`ログイン`・`Tips`・`Wikiにアクセス`に追加
- `ログイン`の項目が増えすぎていたので`実装予定の機能・発生中の不具合`を削除
- `元祖整地鯖(春)wiki`関連の色をグレーに

close #65