### PR TITLE
fix: スキル「マインバースト」の発動タイミング時のマナストーンの切替動作の改善

### DIFF
--- a/src/main/kotlin/click/seichi/gigantic/extension/Player.kt
+++ b/src/main/kotlin/click/seichi/gigantic/extension/Player.kt
@@ -274,7 +274,9 @@ fun Player.updateBag() {
     getOrPut(Keys.BAG).carry(this)
 }
 
-fun Player.fixHandToTool() {
+fun Player.fixHandToTool(player: Player) {
+    // Toolを持った後、マナストーンの切り替え処理が発生する為、マナストーンの状態を反転させておく
+    player.offer(Keys.SPELL_TOGGLE, !player.getOrPut(Keys.SPELL_TOGGLE));
     inventory.heldItemSlot = getOrPut(Keys.BELT).toolSlot
 }
 

--- a/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
@@ -48,9 +48,7 @@ object Skills {
                     p.addPotionEffect(PotionEffect(PotionEffectType.FAST_DIGGING, 100, 2, true, false))
                     SkillSounds.MINE_BURST_ON_FIRE.play(player.eyeLocation)
                     p.updateBelt(true, false)
-                    // Toolを持った後、マナストーンの切り替え処理が発生する為、マナストーンの状態を反転させておく
-                    p.offer(Keys.SPELL_TOGGLE, !p.getOrPut(Keys.SPELL_TOGGLE));
-                    p.fixHandToTool()
+                    p.fixHandToTool(player)
                 }.onFire {
                     if (!p.isValid) return@onFire
                     p.updateBelt(false, false)

--- a/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
+++ b/src/main/kotlin/click/seichi/gigantic/player/skill/Skills.kt
@@ -48,6 +48,8 @@ object Skills {
                     p.addPotionEffect(PotionEffect(PotionEffectType.FAST_DIGGING, 100, 2, true, false))
                     SkillSounds.MINE_BURST_ON_FIRE.play(player.eyeLocation)
                     p.updateBelt(true, false)
+                    // Toolを持った後、マナストーンの切り替え処理が発生する為、マナストーンの状態を反転させておく
+                    p.offer(Keys.SPELL_TOGGLE, !p.getOrPut(Keys.SPELL_TOGGLE));
                     p.fixHandToTool()
                 }.onFire {
                     if (!p.isValid) return@onFire


### PR DESCRIPTION
This PR fix issue #77 